### PR TITLE
Fix amount typo in DealCard

### DIFF
--- a/src/components/DealCard.tsx
+++ b/src/components/DealCard.tsx
@@ -89,13 +89,13 @@ export default function DealCard({
             <span>Shipping cost: ${shipping_cost}</span>
           </Badge>
           <Badge className="bg-accent text-primary p-2" variant="outline">
-            Sub total ammount: ${subTotal}
+            Sub total amount: ${subTotal}
           </Badge>
           <Badge
             className="bg-success text-success-foreground p-2"
             variant="outline"
           >
-            Total ammount: ${amount}
+            Total amount: ${amount}
           </Badge>
         </div>
       </CardHeader>


### PR DESCRIPTION
## Summary
- fix typo in `DealCard` badge labels

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843352f6fbc833194106583a152b956