### PR TITLE
Add task notifications

### DIFF
--- a/src/actions/tasks/getIncompleteTasks.ts
+++ b/src/actions/tasks/getIncompleteTasks.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { getHubspotOwnerIdSession } from "../user/getHubspotOwnerId";
+import { Task } from "@/types/Tasks";
+
+const API = "https://api.hubapi.com";
+
+const hubFetch = (url: string, init: RequestInit = {}, revalidate = 60) =>
+  fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${process.env.HUBSPOT_API_KEY}`,
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+    },
+    next: { revalidate },
+  });
+
+const taskProperties = ["hs_task_subject", "hs_task_status"];
+
+export async function getIncompleteTasks(): Promise<Task[]> {
+  if (!process.env.HUBSPOT_API_KEY) throw new Error("Missing HUBSPOT_API_KEY");
+
+  const ownerId = await getHubspotOwnerIdSession();
+
+  const searchBody = {
+    properties: taskProperties,
+    filterGroups: [
+      {
+        filters: [
+          { propertyName: "hubspot_owner_id", operator: "EQ", value: ownerId },
+          { propertyName: "hs_task_is_completed", operator: "EQ", value: "false" },
+        ],
+      },
+    ],
+    sorts: ["-hs_createdate"],
+    limit: 100,
+  };
+
+  const res = await hubFetch(`${API}/crm/v3/objects/tasks/search`, {
+    method: "POST",
+    body: JSON.stringify(searchBody),
+  });
+
+  if (!res.ok) throw new Error("Failed to fetch tasks: " + res.statusText);
+
+  const json = await res.json();
+  return json.results as Task[];
+}

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useSession } from "next-auth/react";
-import { Bell } from "lucide-react";
+import { TaskNotifications } from "@/components/TaskNotifications";
 
 import { SearchInput } from "@/components/SearchInput";
 
@@ -24,10 +24,7 @@ export function AppHeader() {
       </div>
       <div className="flex items-center gap-4">
         <SearchInput />
-        <button type="button" className="p-2">
-          <Bell className="h-5 w-5" />
-          <span className="sr-only">Notifications</span>
-        </button>
+        <TaskNotifications />
       </div>
     </header>
   );

--- a/src/components/TaskNotifications.tsx
+++ b/src/components/TaskNotifications.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { Bell, CheckCircle } from "lucide-react";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { useIncompleteTasks } from "@/hooks/useIncompleteTasks";
+
+export function TaskNotifications() {
+  const { data: tasks } = useIncompleteTasks();
+  const count = tasks?.length ?? 0;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" className="relative p-2">
+          {count > 0 ? (
+            <>
+              <Bell className="h-5 w-5" />
+              <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
+                {count}
+              </span>
+            </>
+          ) : (
+            <CheckCircle className="h-5 w-5 text-green-500" />
+          )}
+          <span className="sr-only">Tasks Notifications</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        {count > 0 ? (
+          tasks?.map((task) => (
+            <DropdownMenuItem key={task.id}>
+              <Link href="/tasks" className="w-full">
+                {task.properties.hs_task_subject}
+              </Link>
+            </DropdownMenuItem>
+          ))
+        ) : (
+          <DropdownMenuItem disabled>No pending tasks</DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/hooks/useIncompleteTasks.ts
+++ b/src/hooks/useIncompleteTasks.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { getIncompleteTasks } from "@/actions/tasks/getIncompleteTasks";
+import { Task } from "@/types/Tasks";
+
+const ONE_HOUR = 1000 * 60 * 60;
+
+export function useIncompleteTasks() {
+  return useQuery<Task[]>({
+    queryKey: ["incompleteTasks"],
+    queryFn: getIncompleteTasks,
+    staleTime: ONE_HOUR,
+    gcTime: ONE_HOUR,
+    refetchInterval: ONE_HOUR,
+    refetchIntervalInBackground: true,
+  });
+}


### PR DESCRIPTION
## Summary
- add an action to fetch incomplete tasks for the logged user
- provide a React Query hook for periodic refresh
- implement `TaskNotifications` dropdown component
- use the new component in `AppHeader`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ae6955188331907f37cccbd8cb3c