### PR TITLE
Improve analytics data fetching

### DIFF
--- a/src/actions/hubspot/analyticsData.ts
+++ b/src/actions/hubspot/analyticsData.ts
@@ -1,0 +1,210 @@
+"use server";
+
+import { hsFetch } from "@/lib/hubspotFetch";
+import { getHubspotOwnerIdSession } from "@/actions/user/getHubspotOwnerId";
+
+export type ContactLeadInfo = {
+  createdate: string;
+  lead_owner_id?: string | null;
+};
+
+export async function getContactsAndLeadsInRange(
+  fromISO: string,
+  toISO: string,
+) {
+  const ownerId = await getHubspotOwnerIdSession();
+  const contacts: ContactLeadInfo[] = [];
+  let after: string | undefined;
+  do {
+    const body = {
+      filterGroups: [
+        {
+          filters: [
+            {
+              propertyName: "createdate",
+              operator: "BETWEEN",
+              value: fromISO,
+              highValue: toISO,
+            },
+          ],
+        },
+      ],
+      properties: ["createdate", "lead_owner_id"],
+      sorts: ["createdate"],
+      limit: 200,
+      ...(after ? { after } : {}),
+    };
+
+    const page = await hsFetch<{
+      paging?: { next?: { after: string } };
+      results: Array<{
+        properties: { createdate: string; lead_owner_id?: string | null };
+      }>;
+    }>("/crm/v3/objects/contacts/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    contacts.push(...page.results.map((r) => r.properties));
+    after = page.paging?.next?.after;
+  } while (after);
+
+  return { ownerId, contacts };
+}
+
+export type DealInfo = { createdate: string };
+
+export async function getDealsInRange(fromISO: string, toISO: string) {
+  const ownerId = await getHubspotOwnerIdSession();
+  const deals: DealInfo[] = [];
+  let after: string | undefined;
+
+  do {
+    const body = {
+      filterGroups: [
+        {
+          filters: [
+            { propertyName: "lead_owner_id", operator: "EQ", value: ownerId },
+            {
+              propertyName: "createdate",
+              operator: "BETWEEN",
+              value: fromISO,
+              highValue: toISO,
+            },
+          ],
+        },
+      ],
+      properties: ["createdate"],
+      sorts: ["createdate"],
+      limit: 200,
+      ...(after ? { after } : {}),
+    };
+
+    const page = await hsFetch<{
+      paging?: { next?: { after: string } };
+      results: Array<{ properties: { createdate: string } }>;
+    }>("/crm/v3/objects/deals/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    deals.push(...page.results.map((r) => r.properties));
+    after = page.paging?.next?.after;
+  } while (after);
+
+  return deals;
+}
+
+const chunk = <T>(arr: T[], size = 100) =>
+  Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
+    arr.slice(i * size, (i + 1) * size),
+  );
+
+export type QualificationInfo = { createdate: string; diffMs: number };
+
+export async function getQualificationTimesInRange(
+  fromISO: string,
+  toISO: string,
+) {
+  const ownerId = await getHubspotOwnerIdSession();
+  const ids: string[] = [];
+  let after: string | undefined;
+
+  type SearchResp = {
+    paging?: { next: { after: string } };
+    results: { id: string }[];
+  };
+
+  do {
+    const body = {
+      filterGroups: [
+        {
+          filters: [
+            { propertyName: "lead_owner_id", operator: "EQ", value: ownerId },
+            {
+              propertyName: "createdate",
+              operator: "BETWEEN",
+              value: fromISO,
+              highValue: toISO,
+            },
+          ],
+        },
+      ],
+      properties: ["createdate"],
+      limit: 200,
+      sorts: ["createdate"],
+      ...(after ? { after } : {}),
+    };
+
+    const page = await hsFetch<SearchResp>("/crm/v3/objects/contacts/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    ids.push(...page.results.map((r) => r.id));
+    after = page.paging?.next?.after;
+  } while (after);
+
+  if (ids.length === 0) return [] as QualificationInfo[];
+
+  const results: QualificationInfo[] = [];
+  const chunks = chunk(ids);
+
+  await Promise.all(
+    chunks.map(async (chunkIds, chunkIndex) => {
+      const body = {
+        limit: chunkIds.length,
+        properties: ["createdate", "hs_object_id"],
+        propertiesWithHistory: ["lead_owner_id"],
+        inputs: chunkIds.map((id) => ({ id })),
+      };
+
+      try {
+        const data = await hsFetch<{
+          results: Array<{
+            properties: { createdate: string; hs_object_id: string };
+            propertiesWithHistory: {
+              lead_owner_id: { value: string; timestamp: string }[];
+            };
+          }>;
+        }>("/crm/v3/objects/contacts/batch/read", {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+
+        for (const c of data.results) {
+          const created = Date.parse(c.properties.createdate);
+
+          if (
+            !c.propertiesWithHistory?.lead_owner_id ||
+            c.propertiesWithHistory.lead_owner_id.length === 0
+          ) {
+            continue;
+          }
+
+          const historyItems = c.propertiesWithHistory.lead_owner_id.filter(
+            (v) => v.value === ownerId,
+          );
+
+          if (historyItems.length === 0) {
+            continue;
+          }
+
+          const first = [...historyItems].sort(
+            (a, b) => Date.parse(a.timestamp) - Date.parse(b.timestamp),
+          )[0];
+
+          if (first) {
+            const assignedMs = Date.parse(first.timestamp);
+            const diffMs = assignedMs - created;
+            results.push({ createdate: c.properties.createdate, diffMs });
+          }
+        }
+      } catch (error) {
+        console.error(`Error processing chunk ${chunkIndex}:`, error);
+      }
+    }),
+  );
+
+  return results;
+}

--- a/src/actions/hubspot/getAverageQtime.ts
+++ b/src/actions/hubspot/getAverageQtime.ts
@@ -52,7 +52,7 @@ export async function getAverageQualificationTime(
         },
       ],
       properties: ["createdate"],
-      limit: 100,
+      limit: 200,
       sorts: ["createdate"],
       ...(after ? { after } : {}),
     };

--- a/src/actions/hubspot/qualifiedLeads.ts
+++ b/src/actions/hubspot/qualifiedLeads.ts
@@ -130,7 +130,7 @@ async function leadsQualified(userId: string, timeRange: string = "weekly") {
             },
           ],
           sorts: ["-createdate"],
-          limit: 100,
+          limit: 200,
         }),
       }
     );

--- a/src/components/LeadsAnalytics/AverageQTime.tsx
+++ b/src/components/LeadsAnalytics/AverageQTime.tsx
@@ -7,36 +7,19 @@ import {
 } from "@/components/ui/card";
 import { Clock, TrendingDown, TrendingUp } from "lucide-react";
 import { calculatePercentageChange } from "@/lib/utils";
-import { getAverageQualificationTime } from "@/actions/hubspot/getAverageQtime";
 
 type AverageQualificationTimeProps = {
-  currentDateParams: {
-    from: string;
-    to: string;
-  };
-  previousDateParams: {
-    from: string;
-    to: string;
-  };
+  current: { displayValue: number; unit: string };
+  previous: { displayValue: number; unit: string };
 };
 
-export async function AverageQualificationTime({
-  currentDateParams,
-  previousDateParams,
+export function AverageQualificationTime({
+  current,
+  previous,
 }: AverageQualificationTimeProps) {
-  const qualificationTime = await getAverageQualificationTime(
-    currentDateParams.from,
-    currentDateParams.to
-  );
-
-  const previousQualificationTime = await getAverageQualificationTime(
-    previousDateParams.from,
-    previousDateParams.to
-  );
-
   const { percentageChange, formattedPercentage } = calculatePercentageChange(
-    qualificationTime.displayValue,
-    previousQualificationTime.displayValue
+    current.displayValue,
+    previous.displayValue,
   );
 
   let textColorClass = "text-primary";
@@ -61,7 +44,7 @@ export async function AverageQualificationTime({
       </CardHeader>
       <CardContent>
         <div className="text-3xl font-bold">
-          {qualificationTime.displayValue} {qualificationTime.unit}
+          {current.displayValue} {current.unit}
         </div>
         <div className="flex items-center gap-1">
           {ComparisonIcon && (
@@ -70,14 +53,13 @@ export async function AverageQualificationTime({
           <CardDescription
             className={`${textColorClass} font-medium flex items-center`}
           >
-            {previousQualificationTime.displayValue > 0 ? (
+            {previous.displayValue > 0 ? (
               <>
                 {Math.abs(percentageChange) === 0
                   ? "No change"
                   : `${formattedPercentage}% ${percentageChange >= 0 ? "decrease speed" : "increase speed"}`}
                 <span className="ml-1 text-gray-500">
-                  vs previous: {previousQualificationTime.displayValue}{" "}
-                  {previousQualificationTime.unit}
+                  vs previous: {previous.displayValue} {previous.unit}
                 </span>
               </>
             ) : (

--- a/src/components/LeadsAnalytics/ChartContainer.tsx
+++ b/src/components/LeadsAnalytics/ChartContainer.tsx
@@ -1,165 +1,22 @@
 import { AnalyticsChart } from "@/components/LeadsAnalytics/AnalyticsChart";
-import { getLeadsCount } from "@/actions/hubspot/leadsCount";
-import { getContactsCount } from "@/actions/hubspot/contactsCount";
-import {
-  format,
-  differenceInDays,
-  addDays,
-  startOfWeek,
-  endOfWeek,
-  startOfMonth,
-  endOfMonth,
-} from "date-fns";
 import { RadialChart } from "./RadialChart";
 
-type ChartContainerProps = {
-  currentDateParams: {
-    from: string;
-    to: string;
-  };
-  range?: string | string[];
-};
-
-type ChartDataPoint = {
+export type ChartDataPoint = {
   label: string;
   leads: number;
   contacts: number;
 };
 
-// Function to fetch data on a daily basis
-async function fetchDailyData(
-  fromDate: Date,
-  toDate: Date
-): Promise<ChartDataPoint[]> {
-  const result: ChartDataPoint[] = [];
-  let currentDate = new Date(fromDate);
+type ChartContainerProps = {
+  data: ChartDataPoint[];
+  range?: string | string[];
+};
 
-  while (currentDate <= toDate) {
-    const startOfDay = new Date(currentDate);
-    startOfDay.setHours(0, 0, 0, 0);
-
-    const endOfDay = new Date(currentDate);
-    endOfDay.setHours(23, 59, 59, 999);
-
-    const [leadsCount, contactsCount] = await Promise.all([
-      getLeadsCount(startOfDay.toISOString(), endOfDay.toISOString()),
-      getContactsCount(startOfDay.toISOString(), endOfDay.toISOString()),
-    ]);
-
-    result.push({
-      label: format(currentDate, "EEE"), // Mon, Tue, etc.
-      leads: leadsCount,
-      contacts: contactsCount,
-    });
-
-    currentDate = addDays(currentDate, 1);
-  }
-
-  return result;
-}
-
-// Function to fetch data on a weekly basis
-async function fetchWeeklyData(
-  fromDate: Date,
-  toDate: Date
-): Promise<ChartDataPoint[]> {
-  const result: ChartDataPoint[] = [];
-  let currentWeekStart = startOfWeek(fromDate, { weekStartsOn: 1 }); // Start on Monday
-
-  while (currentWeekStart <= toDate) {
-    const weekEnd = endOfWeek(currentWeekStart, { weekStartsOn: 1 });
-    const adjustedWeekEnd = weekEnd > toDate ? toDate : weekEnd;
-
-    const [leadsCount, contactsCount] = await Promise.all([
-      getLeadsCount(
-        currentWeekStart.toISOString(),
-        adjustedWeekEnd.toISOString()
-      ),
-      getContactsCount(
-        currentWeekStart.toISOString(),
-        adjustedWeekEnd.toISOString()
-      ),
-    ]);
-
-    result.push({
-      label: `${format(currentWeekStart, "MMM d")} - ${format(adjustedWeekEnd, "MMM d")}`,
-      leads: leadsCount,
-      contacts: contactsCount,
-    });
-
-    currentWeekStart = addDays(weekEnd, 1);
-  }
-
-  return result;
-}
-
-// Function to fetch data on a monthly basis
-async function fetchMonthlyData(
-  fromDate: Date,
-  toDate: Date
-): Promise<ChartDataPoint[]> {
-  const result: ChartDataPoint[] = [];
-  let currentMonthStart = startOfMonth(fromDate);
-
-  while (currentMonthStart <= toDate) {
-    const monthEnd = endOfMonth(currentMonthStart);
-    const adjustedMonthEnd = monthEnd > toDate ? toDate : monthEnd;
-
-    const [leadsCount, contactsCount] = await Promise.all([
-      getLeadsCount(
-        currentMonthStart.toISOString(),
-        adjustedMonthEnd.toISOString()
-      ),
-      getContactsCount(
-        currentMonthStart.toISOString(),
-        adjustedMonthEnd.toISOString()
-      ),
-    ]);
-
-    result.push({
-      label: format(currentMonthStart, "MMM"),
-      leads: leadsCount,
-      contacts: contactsCount,
-    });
-
-    // Move to the first day of the next month
-    currentMonthStart = new Date(
-      currentMonthStart.getFullYear(),
-      currentMonthStart.getMonth() + 1,
-      1
-    );
-  }
-
-  return result;
-}
-
-export async function ChartContainer({
-  currentDateParams,
-  range,
-}: ChartContainerProps) {
-  const fromDate = new Date(currentDateParams.from);
-  const toDate = new Date(currentDateParams.to);
-  const daysDifference = differenceInDays(toDate, fromDate);
-
-  let chartData: ChartDataPoint[] = [];
-
-  // For 1 week period or less, show daily data
-  if (daysDifference <= 7) {
-    chartData = await fetchDailyData(fromDate, toDate);
-  }
-  // For 1 month period, show weekly data
-  else if (daysDifference <= 31) {
-    chartData = await fetchWeeklyData(fromDate, toDate);
-  }
-  // For longer periods (e.g., 6 months), show monthly data
-  else {
-    chartData = await fetchMonthlyData(fromDate, toDate);
-  }
-
+export function ChartContainer({ data, range }: ChartContainerProps) {
   return (
     <div className="flex justify-center w-full">
-      <AnalyticsChart data={chartData} />
-      <RadialChart data={chartData} range={range} />
+      <AnalyticsChart data={data} />
+      <RadialChart data={data} range={range} />
     </div>
   );
 }

--- a/src/components/LeadsAnalytics/ContactsTotal.tsx
+++ b/src/components/LeadsAnalytics/ContactsTotal.tsx
@@ -9,36 +9,18 @@ import {
 import { TrendingDown, TrendingUp } from "lucide-react";
 import { calculatePercentageChange } from "@/lib/utils";
 import { HubspotIcon } from "../HubspotIcon";
-import { getContactsCount } from "@/actions/hubspot/contactsCount";
-
 type ContactTotalCountProps = {
-  currentDateParams: {
-    from: string;
-    to: string;
-  };
-  previousDateParams: {
-    from: string;
-    to: string;
-  };
+  currentPeriodCount: number;
+  previousPeriodCount: number;
 };
 
-export async function ContactTotalCount({
-  currentDateParams,
-  previousDateParams,
+export function ContactTotalCount({
+  currentPeriodCount,
+  previousPeriodCount,
 }: ContactTotalCountProps) {
-  const currentPeriodContactCount = await getContactsCount(
-    currentDateParams.from,
-    currentDateParams.to
-  );
-
-  const previousPeriodContactCount = await getContactsCount(
-    previousDateParams.from,
-    previousDateParams.to
-  );
-
   const { percentageChange, formattedPercentage } = calculatePercentageChange(
-    currentPeriodContactCount,
-    previousPeriodContactCount
+    currentPeriodCount,
+    previousPeriodCount,
   );
 
   let textColorClass = "text-primary";
@@ -59,7 +41,7 @@ export async function ContactTotalCount({
         <CardTitle className="">Total new contacts</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="text-3xl font-bold">{currentPeriodContactCount}</div>
+        <div className="text-3xl font-bold">{currentPeriodCount}</div>
         <div className="flex items-center gap-1">
           {ComparisonIcon && (
             <ComparisonIcon className={`h-4 w-4 ${textColorClass}`} />
@@ -67,13 +49,13 @@ export async function ContactTotalCount({
           <CardDescription
             className={`${textColorClass} font-medium flex items-center`}
           >
-            {previousPeriodContactCount > 0 ? (
+            {previousPeriodCount > 0 ? (
               <>
                 {Math.abs(percentageChange) === 0
                   ? "No change"
                   : `${formattedPercentage}% ${percentageChange >= 0 ? "increase" : "decrease"}`}
                 <span className="ml-1 text-gray-500">
-                  vs previous: {previousPeriodContactCount}
+                  vs previous: {previousPeriodCount}
                 </span>
               </>
             ) : (

--- a/src/components/LeadsAnalytics/DealsTotal.tsx
+++ b/src/components/LeadsAnalytics/DealsTotal.tsx
@@ -8,36 +8,19 @@ import {
 import { FileCheck, TrendingUp, TrendingDown } from "lucide-react";
 
 import { calculatePercentageChange } from "@/lib/utils";
-import { getDealsCount } from "@/actions/hubspot/dealsCount";
 
 type LeadTotalCountProps = {
-  currentDateParams: {
-    from: string;
-    to: string;
-  };
-  previousDateParams: {
-    from: string;
-    to: string;
-  };
+  currentPeriodCount: number;
+  previousPeriodCount: number;
 };
 
-export async function DealsTotalCount({
-  currentDateParams,
-  previousDateParams,
+export function DealsTotalCount({
+  currentPeriodCount,
+  previousPeriodCount,
 }: LeadTotalCountProps) {
-  const currentPeriodLeadCount = await getDealsCount(
-    currentDateParams.from,
-    currentDateParams.to
-  );
-
-  const previousPeriodLeadCount = await getDealsCount(
-    previousDateParams.from,
-    previousDateParams.to
-  );
-
   const { percentageChange, formattedPercentage } = calculatePercentageChange(
-    currentPeriodLeadCount,
-    previousPeriodLeadCount
+    currentPeriodCount,
+    previousPeriodCount,
   );
 
   let textColorClass = "text-primary";
@@ -58,7 +41,7 @@ export async function DealsTotalCount({
         <CardTitle className="">Assigned Deals</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="text-3xl font-bold">{currentPeriodLeadCount}</div>
+        <div className="text-3xl font-bold">{currentPeriodCount}</div>
         <div className="flex items-center gap-1">
           {ComparisonIcon && (
             <ComparisonIcon className={`h-4 w-4 ${textColorClass}`} />
@@ -66,13 +49,13 @@ export async function DealsTotalCount({
           <CardDescription
             className={`${textColorClass} font-medium flex items-center`}
           >
-            {previousPeriodLeadCount > 0 ? (
+            {previousPeriodCount > 0 ? (
               <>
                 {Math.abs(percentageChange) === 0
                   ? "No change"
                   : `${formattedPercentage}% ${percentageChange >= 0 ? "increase" : "decrease"}`}
                 <span className="ml-1 text-gray-500">
-                  vs previous: {previousPeriodLeadCount}
+                  vs previous: {previousPeriodCount}
                 </span>
               </>
             ) : (

--- a/src/components/LeadsAnalytics/LeadsTotal.tsx
+++ b/src/components/LeadsAnalytics/LeadsTotal.tsx
@@ -6,37 +6,20 @@ import {
   CardDescription,
 } from "@/components/ui/card";
 import { FileCheck, TrendingUp, TrendingDown } from "lucide-react";
-import { getLeadsCount } from "@/actions/hubspot/leadsCount";
 import { calculatePercentageChange } from "@/lib/utils";
 
 type LeadTotalCountProps = {
-  currentDateParams: {
-    from: string;
-    to: string;
-  };
-  previousDateParams: {
-    from: string;
-    to: string;
-  };
+  currentPeriodCount: number;
+  previousPeriodCount: number;
 };
 
-export async function LeadTotalCount({
-  currentDateParams,
-  previousDateParams,
+export function LeadTotalCount({
+  currentPeriodCount,
+  previousPeriodCount,
 }: LeadTotalCountProps) {
-  const currentPeriodLeadCount = await getLeadsCount(
-    currentDateParams.from,
-    currentDateParams.to
-  );
-
-  const previousPeriodLeadCount = await getLeadsCount(
-    previousDateParams.from,
-    previousDateParams.to
-  );
-
   const { percentageChange, formattedPercentage } = calculatePercentageChange(
-    currentPeriodLeadCount,
-    previousPeriodLeadCount
+    currentPeriodCount,
+    previousPeriodCount,
   );
 
   let textColorClass = "text-primary";
@@ -57,7 +40,7 @@ export async function LeadTotalCount({
         <CardTitle className="">Total new leads</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="text-3xl font-bold">{currentPeriodLeadCount}</div>
+        <div className="text-3xl font-bold">{currentPeriodCount}</div>
         <div className="flex items-center gap-1">
           {ComparisonIcon && (
             <ComparisonIcon className={`h-4 w-4 ${textColorClass}`} />
@@ -65,13 +48,13 @@ export async function LeadTotalCount({
           <CardDescription
             className={`${textColorClass} font-medium flex items-center`}
           >
-            {previousPeriodLeadCount > 0 ? (
+            {previousPeriodCount > 0 ? (
               <>
                 {Math.abs(percentageChange) === 0
                   ? "No change"
                   : `${formattedPercentage}% ${percentageChange >= 0 ? "increase" : "decrease"}`}
                 <span className="ml-1 text-gray-500">
-                  vs previous: {previousPeriodLeadCount}
+                  vs previous: {previousPeriodCount}
                 </span>
               </>
             ) : (


### PR DESCRIPTION
## Summary
- centralize analytics data retrieval using new `analyticsData` actions
- update search limits to 200 for HubSpot requests
- refactor analytics components to accept data via props
- simplify chart container
- update analytics page to fetch once and distribute data

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684468c938108331961c0debe2b596b1