### PR TITLE
Add New Qualification modal trigger from sidebar

### DIFF
--- a/src/app/active-qualifications/page.tsx
+++ b/src/app/active-qualifications/page.tsx
@@ -1,7 +1,11 @@
 import { LeadsQualifiedList } from "@/components/LeadsQualifier/LeadsQualifiedList";
 import PageHeader from "@/components/PageHeader";
+import StartQualificationModal from "@/components/LeadsQualifier/StartQualificationModal";
 
-type SearchParams = { timeRange?: "weekly" | "monthly" | "allTime" };
+type SearchParams = {
+  timeRange?: "weekly" | "monthly" | "allTime";
+  startQualification?: string;
+};
 
 export default async function Page({
   searchParams,
@@ -15,6 +19,8 @@ export default async function Page({
         title="Active Qualifications"
         subtitle="Manage your active qualifications"
       />
+      {/* Trigger modal when URL contains startQualification */}
+      <StartQualificationModal />
       <div className="w-full pr-4">
         <LeadsQualifiedList searchParams={params} />
       </div>

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -11,7 +11,9 @@ import {
   ListChecks,
   ChartLine,
   MessagesSquare,
+  PlusCircle,
 } from "lucide-react";
+import { Fragment } from "react";
 import Shopify from "./Icons/Shopify";
 
 import {
@@ -130,14 +132,29 @@ export function AppSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               {filteredItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <Link href={item.url}>
-                      <item.icon />
-                      <span>{item.title}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
+                <Fragment key={item.title}>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton asChild>
+                      <Link href={item.url}>
+                        <item.icon />
+                        <span>{item.title}</span>
+                      </Link>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
+                  {item.title === "Qualification" && (
+                    <SidebarMenuItem key="new-qualification">
+                      <SidebarMenuButton
+                        asChild
+                        className="pl-6"
+                      >
+                        <Link href="/active-qualifications?startQualification=true">
+                          <PlusCircle />
+                          <span>New Qualification</span>
+                        </Link>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  )}
+                </Fragment>
               ))}
               {session?.user?.accessLevel &&
                 [

--- a/src/components/LeadsQualifier/StartQualificationModal.tsx
+++ b/src/components/LeadsQualifier/StartQualificationModal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { QualificationModal } from "@/components/Modals/LeadQualification/QualificationModal";
+import { useQualificationStore } from "@/store/qualification-store";
+
+export default function StartQualificationModal() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { resetData, setStep } = useQualificationStore();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const shouldOpen = searchParams.get("startQualification");
+    if (shouldOpen) {
+      resetData();
+      setStep("step-one");
+      setOpen(true);
+    }
+  }, [searchParams, resetData, setStep]);
+
+  const handleClose = () => {
+    setOpen(false);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("startQualification");
+    const query = params.toString();
+    const url = query ? `/active-qualifications?${query}` : "/active-qualifications";
+    router.replace(url);
+  };
+
+  return (
+    <QualificationModal isOpen={open} onClose={handleClose} />
+  );
+}


### PR DESCRIPTION
## Summary
- add StartQualificationModal client component
- open modal on `/active-qualifications` when `startQualification` query param is present
- add "New Qualification" subitem to sidebar under Qualification

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b0c2297f48331b992d986cc999c16