### PR TITLE
Add Deal modal to kanban board

### DIFF
--- a/src/app/mydeals/deal-kanban-card.tsx
+++ b/src/app/mydeals/deal-kanban-card.tsx
@@ -12,12 +12,17 @@ import { formatCurrency } from "@/lib/utils";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 
-export const DealCard = ({ deal }: { deal: Deal }) => {
+interface DealCardProps {
+  deal: Deal;
+  onSelect?: (id: string) => void;
+}
+
+export const DealCard = ({ deal, onSelect }: DealCardProps) => {
   const contact = deal.contacts[0];
   const amount = Number.parseFloat(deal.properties.amount || "0");
   const progress = calculateDealProgress(
     deal.properties.createdate,
-    deal.properties.closedate
+    deal.properties.closedate,
   );
 
   // Determine progress color based on percentage
@@ -27,8 +32,23 @@ export const DealCard = ({ deal }: { deal: Deal }) => {
     return "bg-red-500";
   };
 
+  const handleSelect = () => {
+    onSelect?.(deal.id);
+  };
+
   return (
-    <Card className="mb-3 hover:shadow-md transition-shadow cursor-pointer">
+    <Card
+      className="mb-3 hover:shadow-md transition-shadow cursor-pointer"
+      onClick={handleSelect}
+      tabIndex={0}
+      role="button"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleSelect();
+        }
+      }}
+    >
       <CardContent className="p-4">
         <div className="space-y-3">
           <div>

--- a/src/app/mydeals/deal-modal.tsx
+++ b/src/app/mydeals/deal-modal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface DealModalProps {
+  dealId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function DealModal({ dealId, isOpen, onClose }: DealModalProps) {
+  if (!dealId) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Deal Details</DialogTitle>
+        </DialogHeader>
+        <div className="py-2">
+          <p className="text-sm text-muted-foreground">Deal ID: {dealId}</p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/mydeals/deals-kanban-board.tsx
+++ b/src/app/mydeals/deals-kanban-board.tsx
@@ -21,6 +21,7 @@ import {
 } from "./utils";
 import { Deal } from "./deals";
 import { DealCard } from "./deal-kanban-card";
+import { DealModal } from "./deal-modal";
 
 interface DealsKanbanBoardProps {
   deals: Deal[];
@@ -31,11 +32,13 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
   const [selectedPipeline, setSelectedPipeline] = useState<string>("all");
   const [timeFilter, setTimeFilter] = useState<string>("all");
   const [viewMode, setViewMode] = useState<"column" | "list">("column");
+  const [selectedDealId, setSelectedDealId] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Get unique pipelines for filter
   const pipelines = useMemo(() => {
     const uniquePipelines = Array.from(
-      new Set(deals.map((deal) => deal.properties.pipeline))
+      new Set(deals.map((deal) => deal.properties.pipeline)),
     );
     return uniquePipelines.map((pipeline) => ({
       value: pipeline,
@@ -53,7 +56,7 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
         deal.contacts.some((contact) =>
           `${contact.firstname} ${contact.lastname}`
             .toLowerCase()
-            .includes(searchTerm.toLowerCase())
+            .includes(searchTerm.toLowerCase()),
         );
 
       const matchesPipeline =
@@ -65,7 +68,7 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
 
         const progress = calculateDealProgress(
           deal.properties.createdate,
-          deal.properties.closedate
+          deal.properties.closedate,
         );
 
         if (timeFilter === "early" && progress < 30) return true;
@@ -125,7 +128,14 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
 
         <div className="space-y-2 overflow-y-auto flex-grow">
           {deals.map((deal) => (
-            <DealCard key={deal.id} deal={deal} />
+            <DealCard
+              key={deal.id}
+              deal={deal}
+              onSelect={(id) => {
+                setSelectedDealId(id);
+                setIsModalOpen(true);
+              }}
+            />
           ))}
         </div>
       </div>
@@ -240,10 +250,26 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
       {viewMode === "list" && (
         <div className="grid gap-4">
           {filteredDeals.map((deal) => (
-            <DealCard key={deal.id} deal={deal} />
+            <DealCard
+              key={deal.id}
+              deal={deal}
+              onSelect={(id) => {
+                setSelectedDealId(id);
+                setIsModalOpen(true);
+              }}
+            />
           ))}
         </div>
       )}
+
+      <DealModal
+        dealId={selectedDealId}
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setSelectedDealId(null);
+        }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add DealModal component
- open DealModal from DealCard clicks
- keep DealCard keyboard accessible for modal launch
- show modal at kanban board level

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859db4180a883319f1c590888a5758f