### PR TITLE
Add Deal modal components

### DIFF
--- a/src/components/Modals/Deal/DealModal.tsx
+++ b/src/components/Modals/Deal/DealModal.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Loader2 } from "lucide-react";
+import { Deal } from "@/types/dealTypes";
+import { getDealById } from "@/actions/deals/getDealsById";
+import InfoTab from "./InfoTab";
+import LineItemsTab from "./LineItemsTab";
+import EngagementsTab from "./EngagementsTab";
+
+interface DealModalProps {
+  dealId: string | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function DealModal({ dealId, isOpen, onClose }: DealModalProps) {
+  const [activeTab, setActiveTab] = useState("deal-info");
+  const [deal, setDeal] = useState<Deal | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchDeal = async () => {
+      if (!dealId) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getDealById(dealId, true);
+        setDeal(data as Deal);
+      } catch (err) {
+        console.error("Error fetching deal:", err);
+        setError("Failed to load deal information");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (isOpen && dealId) {
+      fetchDeal();
+    }
+  }, [dealId, isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent aria-describedby={undefined} className="sm:max-w-[800px] max-h-[80vh] overflow-y-auto">
+        {isLoading ? (
+          <div className="min-h-[400px] flex items-center justify-center gap-2">
+            <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <span className="ml-2">Loading deal information...</span>
+          </div>
+        ) : error ? (
+          <div className="min-h-[400px] flex items-center justify-center text-destructive">
+            {error}
+          </div>
+        ) : deal ? (
+          <>
+            <DialogHeader className="flex flex-row items-center justify-between">
+              <DialogTitle className="text-xl font-semibold">
+                {deal.properties.dealname}
+              </DialogTitle>
+              <span className="text-sm text-foreground">
+                Created {new Date(deal.properties.createdate).toLocaleDateString()}
+              </span>
+            </DialogHeader>
+
+            <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full mt-2">
+              <TabsList className="grid grid-cols-3 w-full">
+                <TabsTrigger value="deal-info">Deal Info</TabsTrigger>
+                <TabsTrigger value="line-items">Line Items</TabsTrigger>
+                <TabsTrigger value="engagements">Engagements</TabsTrigger>
+              </TabsList>
+
+              <InfoTab deal={deal} />
+              <LineItemsTab dealId={deal.id} />
+              <EngagementsTab dealId={deal.id} />
+            </Tabs>
+
+            <DialogFooter className="mt-4">
+              <Button variant="outline" type="button" onClick={onClose}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <div className="min-h-[200px] flex items-center justify-center text-muted-foreground">
+            No deal information available
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default DealModal;
+

--- a/src/components/Modals/Deal/EngagementsTab.tsx
+++ b/src/components/Modals/Deal/EngagementsTab.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { TabsContent } from "@/components/ui/tabs";
+import { Engagement } from "@/types/engagementsTypes";
+import { getDealEngagements } from "@/actions/getDealEngagements";
+import { Loader2, Mail } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { getEngagementIcon } from "../Contact/utils";
+
+interface EngagementsTabProps {
+  dealId: string;
+}
+
+const EngagementsTab = ({ dealId }: EngagementsTabProps) => {
+  const [engagements, setEngagements] = useState<Engagement[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchEngagements = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getDealEngagements(dealId);
+        setEngagements(
+          (data?.results || []).sort(
+            (a: Engagement, b: Engagement) => b.engagement.timestamp - a.engagement.timestamp
+          )
+        );
+      } catch (err) {
+        console.error("Error fetching engagements:", err);
+        setError("Failed to load engagements");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEngagements();
+  }, [dealId]);
+
+  return (
+    <TabsContent value="engagements" className="mt-4">
+      {loading ? (
+        <div className="min-h-[200px] flex flex-col items-center justify-center gap-2">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <span className="text-sm text-muted-foreground">Loading engagements...</span>
+        </div>
+      ) : error ? (
+        <div className="min-h-[200px] flex items-center justify-center text-destructive">
+          {error}
+        </div>
+      ) : engagements.length > 0 ? (
+        <ScrollArea className="h-[390px] pr-2">
+          <div className="space-y-3">
+            {engagements.map((engagement) => (
+              <Card key={engagement.engagement.id} className="overflow-hidden">
+                <CardHeader className="py-2 px-4">
+                  <div className="flex justify-between items-center">
+                    <div className="flex items-center gap-2">
+                      <div className="bg-muted rounded-full p-1.5">
+                        {getEngagementIcon(engagement.engagement.type)}
+                      </div>
+                      <CardTitle className="text-sm font-medium">
+                        {engagement.metadata.title || engagement.engagement.type}
+                      </CardTitle>
+                    </div>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(engagement.engagement.timestamp).toLocaleDateString()}
+                    </span>
+                  </div>
+                </CardHeader>
+                <CardContent className="py-2 px-4 text-xs text-muted-foreground line-clamp-3">
+                  {engagement.engagement.bodyPreview}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </ScrollArea>
+      ) : (
+        <div className="min-h-[200px] flex flex-col items-center justify-center p-6 bg-muted/30 rounded-lg border border-dashed">
+          <Mail className="h-10 w-10 text-muted-foreground mb-2 opacity-40" />
+          <p className="text-muted-foreground">No engagements found for this deal</p>
+        </div>
+      )}
+    </TabsContent>
+  );
+};
+
+export default EngagementsTab;
+

--- a/src/components/Modals/Deal/InfoTab.tsx
+++ b/src/components/Modals/Deal/InfoTab.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { TabsContent } from "@/components/ui/tabs";
+import { Deal } from "@/types/dealTypes";
+import { getDealStageLabel, getPipelineLabel } from "@/app/mydeals/utils";
+
+interface InfoTabProps {
+  deal: Deal;
+}
+
+const InfoTab = ({ deal }: InfoTabProps) => {
+  const { dealname, amount, dealstage, pipeline, createdate, closedate } =
+    deal.properties;
+
+  const formatCurrency = (value: number | string | undefined) => {
+    if (!value) return "$0.00";
+    const num = typeof value === "string" ? parseFloat(value) : value;
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+    }).format(num);
+  };
+
+  const formatDate = (value?: string) =>
+    value ? new Date(value).toLocaleDateString() : "Not set";
+
+  return (
+    <TabsContent value="deal-info" className="mt-4">
+      <div className="grid grid-cols-2 gap-4 min-h-[200px]">
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Name</span>
+          <span className="text-sm font-medium">{dealname || "N/A"}</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Amount</span>
+          <span className="text-sm font-medium">
+            {formatCurrency(amount)}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Stage</span>
+          <span className="text-sm font-medium">
+            {getDealStageLabel(dealstage || "")}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Pipeline</span>
+          <span className="text-sm font-medium">
+            {getPipelineLabel(pipeline || "")}
+          </span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Created</span>
+          <span className="text-sm font-medium">{formatDate(createdate)}</span>
+        </div>
+        <div className="flex flex-col gap-1">
+          <span className="text-sm text-muted-foreground">Close Date</span>
+          <span className="text-sm font-medium">{formatDate(closedate)}</span>
+        </div>
+      </div>
+    </TabsContent>
+  );
+};
+
+export default InfoTab;
+

--- a/src/components/Modals/Deal/LineItemsTab.tsx
+++ b/src/components/Modals/Deal/LineItemsTab.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { TabsContent } from "@/components/ui/tabs";
+import { LineItem } from "@/types/dealTypes";
+import { getDealLineItems } from "@/actions/getDealLineItems";
+import { Loader2, Package } from "lucide-react";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+interface LineItemsTabProps {
+  dealId: string;
+}
+
+const formatCurrency = (value: string | number | undefined) => {
+  if (!value) return "$0.00";
+  const num = typeof value === "string" ? parseFloat(value) : value;
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(num);
+};
+
+const LineItemsTab = ({ dealId }: LineItemsTabProps) => {
+  const [items, setItems] = useState<LineItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getDealLineItems(dealId);
+        setItems(data);
+      } catch (err) {
+        console.error("Error fetching line items:", err);
+        setError("Failed to load line items");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchItems();
+  }, [dealId]);
+
+  return (
+    <TabsContent value="line-items" className="mt-4">
+      {loading ? (
+        <div className="min-h-[200px] flex flex-col items-center justify-center gap-2">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+          <span className="text-sm text-muted-foreground">Loading line items...</span>
+        </div>
+      ) : error ? (
+        <div className="min-h-[200px] flex items-center justify-center text-destructive">
+          {error}
+        </div>
+      ) : items.length > 0 ? (
+        <ScrollArea className="h-[390px] pr-2">
+          <div className="space-y-4">
+            {items.map((item) => (
+              <Card key={item.id} className="overflow-hidden">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm font-medium">{item.properties.name}</CardTitle>
+                </CardHeader>
+                <CardContent className="pb-2">
+                  <div className="grid grid-cols-3 gap-4 text-sm">
+                    <div>
+                      <span className="text-muted-foreground">Qty:</span> {item.properties.quantity}
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Price:</span> {formatCurrency(item.properties.price)}
+                    </div>
+                    <div>
+                      <span className="text-muted-foreground">Total:</span> {formatCurrency(parseFloat(item.properties.price) * parseFloat(item.properties.quantity))}
+                    </div>
+                  </div>
+                </CardContent>
+                <CardFooter className="bg-muted/30 py-2 flex justify-between">
+                  <span className="text-xs text-muted-foreground">ID: {item.id}</span>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        </ScrollArea>
+      ) : (
+        <div className="min-h-[200px] flex flex-col items-center justify-center p-6 bg-muted/30 rounded-lg border border-dashed">
+          <Package className="h-10 w-10 text-muted-foreground mb-2 opacity-40" />
+          <p className="text-muted-foreground">No line items found for this deal</p>
+        </div>
+      )}
+    </TabsContent>
+  );
+};
+
+export default LineItemsTab;
+


### PR DESCRIPTION
## Summary
- implement Deal modal with tabs for info, line items and engagements
- new InfoTab shows basic deal details
- LineItemsTab loads deal line items
- EngagementsTab loads deal engagements

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859db3d5abc8331ae94ba6c6a2cf43f