### PR TITLE
Add sales agent home view

### DIFF
--- a/src/actions/hubspot/dealsSummary.ts
+++ b/src/actions/hubspot/dealsSummary.ts
@@ -1,0 +1,68 @@
+"use server";
+
+import { hsFetch } from "@/lib/hubspotFetch";
+import { getHubspotOwnerIdSession } from "@/actions/user/getHubspotOwnerId";
+import { dealStage } from "@/app/mydeals/utils";
+
+const PAGE_LIMIT = 100;
+const OLD_PIPELINE_ID = "75e28846-ad0d-4be2-a027-5e1da6590b98";
+
+const WON_STAGES = [
+  dealStage["Closed Won"],
+  dealStage["Closed Won - Complete System"],
+];
+const LOST_STAGES = [
+  dealStage["Closed Lost"],
+  dealStage["Closed Lost - Complete System"],
+];
+
+export type DealsSummary = {
+  open: number;
+  won: number;
+  lost: number;
+  conversionRate: number;
+};
+
+export async function getOwnerDealsSummary(): Promise<DealsSummary> {
+  const ownerId = await getHubspotOwnerIdSession();
+  let after: string | undefined;
+  const summary = { open: 0, won: 0, lost: 0 };
+
+  do {
+    const body = {
+      filterGroups: [
+        {
+          filters: [
+            { propertyName: "hubspot_owner_id", operator: "EQ", value: ownerId },
+            { propertyName: "pipeline", operator: "NEQ", value: OLD_PIPELINE_ID },
+          ],
+        },
+      ],
+      properties: ["dealstage"],
+      limit: PAGE_LIMIT,
+      ...(after ? { after } : {}),
+    };
+
+    const data = await hsFetch<{
+      paging?: { next?: { after: string } };
+      results: Array<{ properties: { dealstage: string } }>;
+    }>("/crm/v3/objects/deals/search", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    data.results.forEach(({ properties }) => {
+      const stage = properties.dealstage;
+      if (WON_STAGES.includes(stage)) summary.won++;
+      else if (LOST_STAGES.includes(stage)) summary.lost++;
+      else summary.open++;
+    });
+
+    after = data.paging?.next?.after;
+  } while (after);
+
+  const total = summary.open + summary.won + summary.lost;
+  const conversionRate = total ? (summary.won / total) * 100 : 0;
+
+  return { ...summary, conversionRate };
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/authOptions";
 import QualificationButton from "@/components/Modals/LeadQualification/QualificationButton";
 import { LeadCountCard } from "@/components/LeadsQualifier/LeadsCountCard";
+import { DealsSummaryCards } from "@/components/SalesOverview/DealsSummaryCards";
 
 async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -30,6 +31,11 @@ async function HomePage() {
           <div className="w-[250px]">
             <LeadCountCard />
           </div>
+        </div>
+      )}
+      {accessLevel === "sales_agent" && (
+        <div className="flex flex-col w-full gap-4">
+          <DealsSummaryCards />
         </div>
       )}
     </div>

--- a/src/components/SalesOverview/DealsSummaryCards.tsx
+++ b/src/components/SalesOverview/DealsSummaryCards.tsx
@@ -1,0 +1,94 @@
+import { Suspense } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Briefcase, ThumbsDown, ThumbsUp, Percent } from "lucide-react";
+import { getOwnerDealsSummary } from "@/actions/hubspot/dealsSummary";
+
+export function DealsSummaryCards() {
+  return (
+    <Suspense fallback={<DealsSummarySkeleton />}> 
+      <DealsSummaryContent />
+    </Suspense>
+  );
+}
+
+async function DealsSummaryContent() {
+  const summary = await getOwnerDealsSummary();
+
+  return (
+    <div className="grid grid-cols-2 gap-4 w-full max-w-md">
+      <StatCard
+        title="Open Deals"
+        value={summary.open.toString()}
+        cardClass="border-blue-300 bg-blue-50"
+        textClass="text-blue-700"
+        Icon={Briefcase}
+      />
+      <StatCard
+        title="Deals Won"
+        value={summary.won.toString()}
+        cardClass="border-green-300 bg-green-50"
+        textClass="text-green-700"
+        Icon={ThumbsUp}
+      />
+      <StatCard
+        title="Deals Lost"
+        value={summary.lost.toString()}
+        cardClass="border-red-300 bg-red-50"
+        textClass="text-red-700"
+        Icon={ThumbsDown}
+      />
+      <StatCard
+        title="Conversion Rate"
+        value={`${summary.conversionRate.toFixed(1)}%`}
+        cardClass="border-purple-300 bg-purple-50"
+        textClass="text-purple-700"
+        Icon={Percent}
+      />
+    </div>
+  );
+}
+
+type StatCardProps = {
+  title: string;
+  value: string;
+  cardClass: string;
+  textClass: string;
+  Icon: React.ComponentType<{ className?: string }>;
+};
+
+function StatCard({ title, value, cardClass, textClass, Icon }: StatCardProps) {
+  return (
+    <Card className={cardClass}>
+      <CardHeader className="flex flex-row items-center gap-2">
+        <Icon className={`h-5 w-5 ${textClass}`} />
+        <CardTitle className={textClass}>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-3xl font-bold ${textClass} mb-1`}>{value}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DealsSummarySkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 w-full max-w-md">
+      {[1, 2, 3, 4].map((i) => (
+        <Card key={i} className="bg-muted">
+          <CardHeader>
+            <Skeleton className="h-5 w-24" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-8 w-16 mb-1" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create API to summarize owned deals
- show sales stats cards for open, won, lost, and conversion rate
- display summary on homepage when user is a sales agent

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf2861c5c833197224f9450f02fc9