### PR TITLE
Add today's meetings card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { authOptions } from "@/lib/authOptions";
 import QualificationButton from "@/components/Modals/LeadQualification/QualificationButton";
 import { LeadCountCard } from "@/components/LeadsQualifier/LeadsCountCard";
 import { DealsSummaryCards } from "@/components/SalesOverview/DealsSummaryCards";
+import TodayMeetingsCard from "@/components/SalesOverview/TodayMeetingsCard";
 
 async function HomePage() {
   const session = await getServerSession(authOptions);
@@ -36,6 +37,7 @@ async function HomePage() {
       {accessLevel === "sales_agent" && (
         <div className="flex flex-col w-full gap-4">
           <DealsSummaryCards />
+          <TodayMeetingsCard />
         </div>
       )}
     </div>

--- a/src/components/SalesOverview/TodayMeetingsCard.tsx
+++ b/src/components/SalesOverview/TodayMeetingsCard.tsx
@@ -1,0 +1,22 @@
+import { getAllOwnersMeetings } from "@/actions/searchOwnerMeetings";
+import { Meeting } from "@/types/meetingTypes";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import TodayMeetingsClient from "./TodayMeetingsClient";
+
+export default async function TodayMeetingsCard() {
+  const meetings = await getAllOwnersMeetings();
+
+  const today = new Date();
+  const startOfDay = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const endOfDay = new Date(startOfDay);
+  endOfDay.setDate(endOfDay.getDate() + 1);
+
+  const todaysMeetings = meetings.filter((m: Meeting) => {
+    const start = m.properties.hs_meeting_start_time;
+    if (!start) return false;
+    const date = new Date(start);
+    return date >= startOfDay && date < endOfDay;
+  });
+
+  return <TodayMeetingsClient meetings={todaysMeetings} />;
+}

--- a/src/components/SalesOverview/TodayMeetingsClient.tsx
+++ b/src/components/SalesOverview/TodayMeetingsClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Meeting } from "@/types/meetingTypes";
+import { MeetingDetailsDialog } from "@/app/my-meetings/meeting-details-dialog";
+import { CalendarEvent } from "@/types/calendarTypes";
+
+function getColorForMeetingOutcome(
+  outcome?: string
+): "default" | "blue" | "green" | "pink" | "purple" | undefined {
+  switch (outcome) {
+    case "COMPLETED":
+      return "green";
+    case "SCHEDULED":
+      return "blue";
+    case "RESCHEDULED":
+      return "purple";
+    case "NO_SHOW":
+      return "pink";
+    case "CANCELED":
+      return "default";
+    default:
+      return "default";
+  }
+}
+
+export default function TodayMeetingsClient({ meetings }: { meetings: Meeting[] }) {
+  const [open, setOpen] = useState(false);
+  const [selectedMeeting, setSelectedMeeting] = useState<Meeting>();
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent>();
+
+  const handleClick = (meeting: Meeting) => {
+    const defaultDate = new Date("2023-01-01T00:00:00Z");
+    const start = meeting.properties.hs_meeting_start_time
+      ? new Date(meeting.properties.hs_meeting_start_time)
+      : defaultDate;
+    const end = meeting.properties.hs_meeting_end_time
+      ? new Date(meeting.properties.hs_meeting_end_time)
+      : new Date(start.getTime() + 60 * 60 * 1000);
+
+    setSelectedMeeting(meeting);
+    setSelectedEvent({
+      id: meeting.id,
+      start,
+      end,
+      title: meeting.properties.hs_meeting_title || "Untitled Meeting",
+      color: getColorForMeetingOutcome(meeting.properties.hs_meeting_outcome),
+    });
+    setOpen(true);
+  };
+
+  return (
+    <>
+      <Card className="shadow-sm">
+        <CardHeader>
+          <CardTitle>Today's Meetings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {meetings.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No meetings for today.</p>
+          ) : (
+            <ul className="space-y-2">
+              {meetings.map((m) => (
+                <li key={m.id}>
+                  <button
+                    onClick={() => handleClick(m)}
+                    className="text-left w-full hover:underline"
+                  >
+                    <span className="font-medium">
+                      {m.properties.hs_meeting_start_time &&
+                        new Date(m.properties.hs_meeting_start_time).toLocaleTimeString([], {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      {" - "}
+                      {m.properties.hs_meeting_title || "Untitled Meeting"}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+      <MeetingDetailsDialog
+        open={open}
+        onOpenChange={setOpen}
+        meeting={selectedMeeting}
+        calendarEvent={selectedEvent}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- show a card with today's meetings on the home page when the user is a sales agent
- open meeting details dialog on click

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa3539108331bea7b8fb7ffc2453