### PR TITLE
Add win/loss chart with pipeline filter

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,9 +5,14 @@ import { authOptions } from "@/lib/authOptions";
 import QualificationButton from "@/components/Modals/LeadQualification/QualificationButton";
 import { LeadCountCard } from "@/components/LeadsQualifier/LeadsCountCard";
 import { DealsSummaryCards } from "@/components/SalesOverview/DealsSummaryCards";
+import { DealsWonLostChart } from "@/components/SalesOverview/DealsWonLostChart";
 import TodayMeetingsCard from "@/components/SalesOverview/TodayMeetingsCard";
 
-async function HomePage() {
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+async function HomePage({ searchParams }: { searchParams: SearchParams }) {
+  const params = await searchParams;
+  const pipeline = typeof params.pipeline === "string" ? params.pipeline : params.pipeline?.[0];
   const session = await getServerSession(authOptions);
   const userName = session?.user?.name || "User";
   const accessLevel = session?.user?.accessLevel;
@@ -37,6 +42,7 @@ async function HomePage() {
       {accessLevel === "sales_agent" && (
         <div className="flex flex-col w-full gap-4">
           <DealsSummaryCards />
+          <DealsWonLostChart pipeline={pipeline} />
           <TodayMeetingsCard />
         </div>
       )}

--- a/src/components/SalesOverview/DealsWonLostChart.tsx
+++ b/src/components/SalesOverview/DealsWonLostChart.tsx
@@ -1,0 +1,58 @@
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+import { PolarAngleAxis, PolarRadiusAxis, RadialBarChart, RadialBar, Label } from "recharts";
+import { getOwnerDealsWonLost } from "@/actions/hubspot/dealsSummary";
+import { PipelineSelect } from "./PipelineSelect";
+
+const chartConfig = { rate: { label: "Rate", color: "#4ade80" } } satisfies ChartConfig;
+
+export async function DealsWonLostChart({ pipeline }: { pipeline?: string }) {
+  const { won, lost } = await getOwnerDealsWonLost(pipeline);
+  const total = won + lost;
+  const rate = total ? (won / total) * 100 : 0;
+
+  return (
+    <Card className="mr-4 flex flex-col">
+      <CardHeader className="items-center pb-0">
+        <CardTitle>Win rate</CardTitle>
+        <CardDescription>Deals Won vs Lost</CardDescription>
+      </CardHeader>
+      <CardContent className="mb-4">
+        <ChartContainer config={chartConfig} className="mx-auto aspect-square max-h-[250px]">
+          <RadialBarChart
+            data={[{ name: "rate", value: rate, fill: "#4ade80" }]}
+            startAngle={90}
+            endAngle={-270}
+            innerRadius={80}
+            outerRadius={140}
+            barSize={20}
+          >
+            <PolarAngleAxis type="number" domain={[0, 100]} tick={false} />
+            <RadialBar dataKey="value" cornerRadius={10} background={{ fill: "hsl(var(--muted))" }} />
+            <PolarRadiusAxis tick={false} axisLine={false}>
+              <Label
+                content={({ viewBox }) => {
+                  if (!viewBox || !("cx" in viewBox) || !("cy" in viewBox)) return null;
+                  const { cx, cy } = viewBox;
+                  return (
+                    <text x={cx} y={cy} textAnchor="middle" dominantBaseline="middle">
+                      <tspan x={cx} y={(cy as number) - 10} className="fill-foreground text-4xl font-bold">
+                        {rate.toFixed(1)}%
+                      </tspan>
+                      <tspan x={cx} y={(cy as number) + 18} className="fill-muted-foreground text-sm">
+                        {won} / {lost}
+                      </tspan>
+                    </text>
+                  );
+                }}
+              />
+            </PolarRadiusAxis>
+          </RadialBarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className="justify-center">
+        <PipelineSelect />
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/SalesOverview/PipelineSelect.tsx
+++ b/src/components/SalesOverview/PipelineSelect.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
+import { Loader2 } from "lucide-react";
+
+const pipelines = [
+  { label: "Both Pipelines", value: "all" },
+  { label: "Mbtek - Complete System", value: "732661879" },
+  { label: "Mbtek - Instant Quote", value: "732682097" },
+];
+
+export function PipelineSelect() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const selected = searchParams.get("pipeline") || "all";
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "all") params.delete("pipeline");
+    else params.set("pipeline", value);
+
+    startTransition(() => {
+      router.push(`?${params.toString()}`, { scroll: false });
+      router.refresh();
+    });
+  };
+
+  const display = pipelines.find((p) => p.value === selected)?.label || "Both Pipelines";
+
+  return (
+    <Select value={selected} onValueChange={handleChange}>
+      <SelectTrigger className="w-[200px]">
+        {isPending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+        <SelectValue>{display}</SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {pipelines.map((p) => (
+          <SelectItem key={p.value} value={p.value}>
+            {p.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}


### PR DESCRIPTION
## Summary
- compute win vs lost deal counts via new `getOwnerDealsWonLost` action
- allow selecting pipeline with new `PipelineSelect` component
- show a radial chart of won/lost progress on the homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c7caaadc08331a7367c64bc19d02f