### PR TITLE
Implement complete system multi-step pages

### DIFF
--- a/src/actions/contact/patchDealProperties.ts
+++ b/src/actions/contact/patchDealProperties.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidateTag } from "next/cache";
 import { revalidatePath } from "next/cache";
 
 type DealProperties = {
@@ -43,7 +44,7 @@ export async function patchDealProperties(
     }
 
     const dealData = await response.json();
-
+    revalidateTag("contact-deals");
     revalidatePath("/mydeals");
     return dealData;
   } catch (error) {

--- a/src/actions/deals/getDealsById.ts
+++ b/src/actions/deals/getDealsById.ts
@@ -28,7 +28,7 @@ export async function getDealById(
     }
 
     const data = await response.json();
-    console.log("Deal data loaded:", data);
+
     return data;
   } catch (error) {
     console.error(`Error in getDealDetails for deal ${dealId}:`, error);

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
@@ -31,6 +31,11 @@ export default async function DealsLayout({ children, params }: Props) {
       route: "step-four",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-four`,
     },
+    {
+      title: "Step Five",
+      route: "step-five",
+      link: `/forms/complete-system/${id}/deal/${dealId}/step-five`,
+    },
 
     {
       title: "Review",

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
@@ -12,27 +12,27 @@ export default async function DealsLayout({ children, params }: Props) {
 
   const steps = [
     {
-      title: "Step One",
+      title: "Building needs",
       route: "step-one",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-one`,
     },
     {
-      title: "Step Two",
+      title: "Zones Info",
       route: "step-two",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-two`,
     },
     {
-      title: "Step Three",
+      title: "Documents",
       route: "step-three",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-three`,
     },
     {
-      title: "Step Four",
+      title: "Billing",
       route: "step-four",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-four`,
     },
     {
-      title: "Step Five",
+      title: "Shipping",
       route: "step-five",
       link: `/forms/complete-system/${id}/deal/${dealId}/step-five`,
     },
@@ -50,7 +50,7 @@ export default async function DealsLayout({ children, params }: Props) {
         title="Complete System - Quote creation"
         subtitle={`Creating quote for deal ID: ${dealId}`}
       />
-      <div className="mt-1 mb-28 flex flex-col gap-x-16 text-white lg:flex-row">
+      <div className="mt-1 mb-28 flex flex-col gap-x-16 text-primary lg:flex-row">
         <StepNavigation steps={steps} />
         <div className="w-full">{children}</div>
       </div>

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/review/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/review/page.tsx
@@ -1,8 +1,12 @@
 import { getDealById } from "@/actions/deals/getDealsById";
 import { GetContactById } from "@/actions/getContactById";
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
   const contactData = await GetContactById(id, true);
 
@@ -10,7 +14,7 @@ export default async function Page({ params }: { params: { id: string; dealId: s
     <div className="p-4 space-y-4">
       <h2 className="text-xl font-semibold">Review Information</h2>
       <pre className="whitespace-pre-wrap text-sm bg-muted p-4 rounded">
-{JSON.stringify({ contact: contactData, deal: dealData }, null, 2)}
+        {JSON.stringify({ contact: contactData, deal: dealData }, null, 2)}
       </pre>
     </div>
   );

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/review/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/review/page.tsx
@@ -1,0 +1,17 @@
+import { getDealById } from "@/actions/deals/getDealsById";
+import { GetContactById } from "@/actions/getContactById";
+
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+  const contactData = await GetContactById(id, true);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-xl font-semibold">Review Information</h2>
+      <pre className="whitespace-pre-wrap text-sm bg-muted p-4 rounded">
+{JSON.stringify({ contact: contactData, deal: dealData }, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import ShippingContent from "@/components/Modals/TechnicalInformation/ShippingContent";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+
+interface StepFiveFormProps {
+  dealId: string;
+  contactId: string;
+  initialData: any;
+  billingData: any;
+}
+
+export default function StepFiveForm({ dealId, contactId, initialData, billingData }: StepFiveFormProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const handleComplete = async (data: any) => {
+    await patchDealProperties(dealId, {
+      shipping_first_name: data.shipping_first_name,
+      shipping_last_name: data.shipping_last_name,
+      shipping_email: data.shipping_email,
+      shipping_phone: data.shipping_phone,
+      shipping_address: data.shipping_address,
+      shipping_city: data.shipping_city,
+      shipping_country: data.shipping_country,
+      shipping_province: data.shipping_province,
+      shipping_zip_code: data.shipping_zip_code,
+      delivery_type: data.delivery_type,
+      dropoff_condition: data.dropoff_condition,
+      last_step: "review",
+    });
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/review`);
+  };
+
+  return (
+    <ShippingContent
+      onComplete={handleComplete}
+      initialData={initialData}
+      billingData={billingData}
+      formRef={formRef}
+    />
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import ShippingContent from "@/components/Modals/TechnicalInformation/ShippingContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { Button } from "@/components/ui/button";
 
 interface StepFiveFormProps {
   dealId: string;
@@ -11,7 +12,12 @@ interface StepFiveFormProps {
   billingData: any;
 }
 
-export default function StepFiveForm({ dealId, contactId, initialData, billingData }: StepFiveFormProps) {
+export default function StepFiveForm({
+  dealId,
+  contactId,
+  initialData,
+  billingData,
+}: StepFiveFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -33,12 +39,35 @@ export default function StepFiveForm({ dealId, contactId, initialData, billingDa
     router.push(`/forms/complete-system/${contactId}/deal/${dealId}/review`);
   };
 
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(
+        new Event("submit", { cancelable: true, bubbles: true })
+      );
+    }
+  };
+
+  const handleBack = () => {
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-four`);
+  };
+
   return (
-    <ShippingContent
-      onComplete={handleComplete}
-      initialData={initialData}
-      billingData={billingData}
-      formRef={formRef}
-    />
+    <div className="space-y-6">
+      <ShippingContent
+        onComplete={handleComplete}
+        initialData={initialData}
+        billingData={billingData}
+        formRef={formRef}
+      />
+      <div className="flex justify-between mt-8 pt-4 border-t border-gray-200">
+        <Button type="button" variant="outline" onClick={handleBack}>
+          Back
+        </Button>
+
+        <Button type="button" onClick={handleSubmit}>
+          Save & Continue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/page.tsx
@@ -2,35 +2,89 @@ import { getDealById } from "@/actions/deals/getDealsById";
 import { GetContactById } from "@/actions/getContactById";
 import StepFiveForm from "./StepFiveForm";
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
   const contactData = await GetContactById(id, true);
 
   const initialData = {
     delivery_type: dealData?.properties?.delivery_type || "",
     dropoff_condition: dealData?.properties?.dropoff_condition || "",
-    shipping_first_name: dealData?.properties?.shipping_first_name || contactData?.properties?.firstname || "",
-    shipping_last_name: dealData?.properties?.shipping_last_name || contactData?.properties?.lastname || "",
-    shipping_email: dealData?.properties?.shipping_email || contactData?.properties?.email || "",
-    shipping_phone: dealData?.properties?.shipping_phone || contactData?.properties?.phone || "",
-    shipping_address: dealData?.properties?.shipping_address || contactData?.properties?.shipping_address || "",
-    shipping_city: dealData?.properties?.shipping_city || contactData?.properties?.shipping_city || "",
-    shipping_country: dealData?.properties?.shipping_country || contactData?.properties?.shipping_country || "",
-    shipping_province: dealData?.properties?.shipping_province || contactData?.properties?.shipping_province || "",
-    shipping_zip_code: dealData?.properties?.shipping_zip_code || contactData?.properties?.shipping_zip_code || "",
+    shipping_first_name:
+      dealData?.properties?.shipping_first_name ||
+      contactData?.properties?.firstname ||
+      "",
+    shipping_last_name:
+      dealData?.properties?.shipping_last_name ||
+      contactData?.properties?.lastname ||
+      "",
+    shipping_email:
+      dealData?.properties?.shipping_email ||
+      contactData?.properties?.email ||
+      "",
+    shipping_phone:
+      dealData?.properties?.shipping_phone ||
+      contactData?.properties?.phone ||
+      "",
+    shipping_address:
+      dealData?.properties?.shipping_address ||
+      contactData?.properties?.shipping_address ||
+      "",
+    shipping_city:
+      dealData?.properties?.shipping_city ||
+      contactData?.properties?.shipping_city ||
+      "",
+    shipping_country:
+      dealData?.properties?.shipping_country ||
+      contactData?.properties?.shipping_country ||
+      "",
+    shipping_province:
+      dealData?.properties?.shipping_province ||
+      contactData?.properties?.shipping_province ||
+      "",
+    shipping_zip_code:
+      dealData?.properties?.shipping_zip_code ||
+      contactData?.properties?.shipping_zip_code ||
+      "",
   };
 
   const billingData = {
-    zipCode: dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
-    firstName: dealData?.properties?.billing_first_name || contactData?.properties?.firstname || "",
-    lastName: dealData?.properties?.billing_last_name || contactData?.properties?.lastname || "",
-    email: dealData?.properties?.billing_email || contactData?.properties?.email || "",
-    phone: dealData?.properties?.billing_phone || contactData?.properties?.phone || "",
-    address: dealData?.properties?.billing_address || contactData?.properties?.address || "",
-    city: dealData?.properties?.billing_city || contactData?.properties?.city || "",
-    state: dealData?.properties?.billing_state || contactData?.properties?.state || "",
-    country: dealData?.properties?.billing_country || contactData?.properties?.country || "",
+    zipCode:
+      dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
+    firstName:
+      dealData?.properties?.billing_first_name ||
+      contactData?.properties?.firstname ||
+      "",
+    lastName:
+      dealData?.properties?.billing_last_name ||
+      contactData?.properties?.lastname ||
+      "",
+    email:
+      dealData?.properties?.billing_email ||
+      contactData?.properties?.email ||
+      "",
+    phone:
+      dealData?.properties?.billing_phone ||
+      contactData?.properties?.phone ||
+      "",
+    address:
+      dealData?.properties?.billing_address ||
+      contactData?.properties?.address ||
+      "",
+    city:
+      dealData?.properties?.billing_city || contactData?.properties?.city || "",
+    state:
+      dealData?.properties?.billing_state ||
+      contactData?.properties?.state ||
+      "",
+    country:
+      dealData?.properties?.billing_country ||
+      contactData?.properties?.country ||
+      "",
   };
 
   return (

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/page.tsx
@@ -1,0 +1,46 @@
+import { getDealById } from "@/actions/deals/getDealsById";
+import { GetContactById } from "@/actions/getContactById";
+import StepFiveForm from "./StepFiveForm";
+
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+  const contactData = await GetContactById(id, true);
+
+  const initialData = {
+    delivery_type: dealData?.properties?.delivery_type || "",
+    dropoff_condition: dealData?.properties?.dropoff_condition || "",
+    shipping_first_name: dealData?.properties?.shipping_first_name || contactData?.properties?.firstname || "",
+    shipping_last_name: dealData?.properties?.shipping_last_name || contactData?.properties?.lastname || "",
+    shipping_email: dealData?.properties?.shipping_email || contactData?.properties?.email || "",
+    shipping_phone: dealData?.properties?.shipping_phone || contactData?.properties?.phone || "",
+    shipping_address: dealData?.properties?.shipping_address || contactData?.properties?.shipping_address || "",
+    shipping_city: dealData?.properties?.shipping_city || contactData?.properties?.shipping_city || "",
+    shipping_country: dealData?.properties?.shipping_country || contactData?.properties?.shipping_country || "",
+    shipping_province: dealData?.properties?.shipping_province || contactData?.properties?.shipping_province || "",
+    shipping_zip_code: dealData?.properties?.shipping_zip_code || contactData?.properties?.shipping_zip_code || "",
+  };
+
+  const billingData = {
+    zipCode: dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
+    firstName: dealData?.properties?.billing_first_name || contactData?.properties?.firstname || "",
+    lastName: dealData?.properties?.billing_last_name || contactData?.properties?.lastname || "",
+    email: dealData?.properties?.billing_email || contactData?.properties?.email || "",
+    phone: dealData?.properties?.billing_phone || contactData?.properties?.phone || "",
+    address: dealData?.properties?.billing_address || contactData?.properties?.address || "",
+    city: dealData?.properties?.billing_city || contactData?.properties?.city || "",
+    state: dealData?.properties?.billing_state || contactData?.properties?.state || "",
+    country: dealData?.properties?.billing_country || contactData?.properties?.country || "",
+  };
+
+  return (
+    <div className="p-4">
+      <StepFiveForm
+        dealId={dealId}
+        contactId={id}
+        initialData={initialData}
+        billingData={billingData}
+      />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import QuoteBillingContent from "@/components/Modals/TechnicalInformation/QuoteBillingContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { Button } from "@/components/ui/button";
 
 interface StepFourFormProps {
   dealId: string;
@@ -10,7 +11,11 @@ interface StepFourFormProps {
   initialData: any;
 }
 
-export default function StepFourForm({ dealId, contactId, initialData }: StepFourFormProps) {
+export default function StepFourForm({
+  dealId,
+  contactId,
+  initialData,
+}: StepFourFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -30,11 +35,37 @@ export default function StepFourForm({ dealId, contactId, initialData }: StepFou
     router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-five`);
   };
 
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(
+        new Event("submit", { cancelable: true, bubbles: true })
+      );
+    }
+  };
+
+  const handleBack = () => {
+    router.push(
+      `/forms/complete-system/${contactId}/deal/${dealId}/step-three`
+    );
+  };
+
   return (
-    <QuoteBillingContent
-      onComplete={handleComplete}
-      initialData={initialData}
-      formRef={formRef}
-    />
+    <div className="space-y-6">
+      <QuoteBillingContent
+        onComplete={handleComplete}
+        initialData={initialData}
+        formRef={formRef}
+      />
+
+      <div className="flex justify-between mt-8 pt-4 border-t border-gray-200">
+        <Button type="button" variant="outline" onClick={handleBack}>
+          Back
+        </Button>
+
+        <Button type="button" onClick={handleSubmit}>
+          Save & Continue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import QuoteBillingContent from "@/components/Modals/TechnicalInformation/QuoteBillingContent";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+
+interface StepFourFormProps {
+  dealId: string;
+  contactId: string;
+  initialData: any;
+}
+
+export default function StepFourForm({ dealId, contactId, initialData }: StepFourFormProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const handleComplete = async (data: any) => {
+    await patchDealProperties(dealId, {
+      billing_zip: data.zipCode,
+      billing_first_name: data.firstName,
+      billing_last_name: data.lastName,
+      billing_email: data.email,
+      billing_phone: data.phone,
+      billing_address: data.address,
+      billing_city: data.city,
+      billing_state: data.state,
+      billing_country: data.country,
+      last_step: "step-5",
+    });
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-five`);
+  };
+
+  return (
+    <QuoteBillingContent
+      onComplete={handleComplete}
+      initialData={initialData}
+      formRef={formRef}
+    />
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/page.tsx
@@ -1,0 +1,27 @@
+import { getDealById } from "@/actions/deals/getDealsById";
+import { GetContactById } from "@/actions/getContactById";
+import StepFourForm from "./StepFourForm";
+
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+  const contactData = await GetContactById(id, true);
+
+  const initialData = {
+    zipCode: dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
+    firstName: dealData?.properties?.billing_first_name || contactData?.properties?.firstname || "",
+    lastName: dealData?.properties?.billing_last_name || contactData?.properties?.lastname || "",
+    email: dealData?.properties?.billing_email || contactData?.properties?.email || "",
+    phone: dealData?.properties?.billing_phone || contactData?.properties?.phone || "",
+    address: dealData?.properties?.billing_address || contactData?.properties?.address || "",
+    city: dealData?.properties?.billing_city || contactData?.properties?.city || "",
+    state: dealData?.properties?.billing_state || contactData?.properties?.state || "",
+    country: dealData?.properties?.billing_country || contactData?.properties?.country || "",
+  };
+
+  return (
+    <div className="p-4">
+      <StepFourForm dealId={dealId} contactId={id} initialData={initialData} />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-four/page.tsx
@@ -2,21 +2,48 @@ import { getDealById } from "@/actions/deals/getDealsById";
 import { GetContactById } from "@/actions/getContactById";
 import StepFourForm from "./StepFourForm";
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
   const contactData = await GetContactById(id, true);
 
   const initialData = {
-    zipCode: dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
-    firstName: dealData?.properties?.billing_first_name || contactData?.properties?.firstname || "",
-    lastName: dealData?.properties?.billing_last_name || contactData?.properties?.lastname || "",
-    email: dealData?.properties?.billing_email || contactData?.properties?.email || "",
-    phone: dealData?.properties?.billing_phone || contactData?.properties?.phone || "",
-    address: dealData?.properties?.billing_address || contactData?.properties?.address || "",
-    city: dealData?.properties?.billing_city || contactData?.properties?.city || "",
-    state: dealData?.properties?.billing_state || contactData?.properties?.state || "",
-    country: dealData?.properties?.billing_country || contactData?.properties?.country || "",
+    zipCode:
+      dealData?.properties?.billing_zip || contactData?.properties?.zip || "",
+    firstName:
+      dealData?.properties?.billing_first_name ||
+      contactData?.properties?.firstname ||
+      "",
+    lastName:
+      dealData?.properties?.billing_last_name ||
+      contactData?.properties?.lastname ||
+      "",
+    email:
+      dealData?.properties?.billing_email ||
+      contactData?.properties?.email ||
+      "",
+    phone:
+      dealData?.properties?.billing_phone ||
+      contactData?.properties?.phone ||
+      "",
+    address:
+      dealData?.properties?.billing_address ||
+      contactData?.properties?.address ||
+      "",
+    city:
+      dealData?.properties?.billing_city || contactData?.properties?.city || "",
+    state:
+      dealData?.properties?.billing_state ||
+      contactData?.properties?.state ||
+      "",
+    country:
+      dealData?.properties?.billing_country ||
+      contactData?.properties?.country ||
+      "",
   };
 
   return (

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/StepOneForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/StepOneForm.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import BuildingNeedsContent from "@/components/Modals/TechnicalInformation/BuildingNeedsContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { Button } from "@/components/ui/button";
 
 interface StepOneFormProps {
   dealId: string;
@@ -10,7 +11,11 @@ interface StepOneFormProps {
   initialData: any;
 }
 
-export default function StepOneForm({ dealId, contactId, initialData }: StepOneFormProps) {
+export default function StepOneForm({
+  dealId,
+  contactId,
+  initialData,
+}: StepOneFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -25,12 +30,28 @@ export default function StepOneForm({ dealId, contactId, initialData }: StepOneF
     });
     router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-two`);
   };
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(
+        new Event("submit", { cancelable: true, bubbles: true })
+      );
+    }
+  };
 
   return (
-    <BuildingNeedsContent
-      onComplete={handleComplete}
-      initialData={initialData}
-      formRef={formRef}
-    />
+    <div className="space-y-6">
+      <BuildingNeedsContent
+        onComplete={handleComplete}
+        initialData={initialData}
+        formRef={formRef}
+      />
+
+      {/* Botones de navegación */}
+      <div className="flex items-center justify-end mt-8 pt-4 border-t border-gray-200">
+        <Button type="button" onClick={handleSubmit}>
+          Save & Continue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/StepOneForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/StepOneForm.tsx
@@ -1,0 +1,36 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import BuildingNeedsContent from "@/components/Modals/TechnicalInformation/BuildingNeedsContent";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+
+interface StepOneFormProps {
+  dealId: string;
+  contactId: string;
+  initialData: any;
+}
+
+export default function StepOneForm({ dealId, contactId, initialData }: StepOneFormProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const handleComplete = async (data: any) => {
+    await patchDealProperties(dealId, {
+      year_of_construction: Number(data.yearOfConstruction),
+      insulation_type: data.insulationType,
+      specific_needs: data.specificNeeds.join(";"),
+      other_specific_need: data.otherSpecificNeed || "",
+      installation_responsible: data.installationResponsible,
+      last_step: "zones-information",
+    });
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-two`);
+  };
+
+  return (
+    <BuildingNeedsContent
+      onComplete={handleComplete}
+      initialData={initialData}
+      formRef={formRef}
+    />
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/page.tsx
@@ -2,21 +2,23 @@ import { getDealById } from "@/actions/deals/getDealsById";
 import { GetContactById } from "@/actions/getContactById";
 import StepOneForm from "./StepOneForm";
 
-interface Props {
-  params: { id: string; dealId: string };
-}
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
   const contactData = await GetContactById(id, true);
 
   const initialData = {
     yearOfConstruction: dealData?.properties?.year_of_construction || "",
     insulationType: dealData?.properties?.insulation_type || "",
-    specificNeeds: dealData?.properties?.specific_needs?.split(";").filter(Boolean) || [],
+    specificNeeds:
+      dealData?.properties?.specific_needs?.split(";").filter(Boolean) || [],
     otherSpecificNeed: dealData?.properties?.other_specific_need || "",
-    installationResponsible: dealData?.properties?.installation_responsible || "",
+    installationResponsible:
+      dealData?.properties?.installation_responsible || "",
   };
 
   return (

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-one/page.tsx
@@ -1,13 +1,27 @@
 import { getDealById } from "@/actions/deals/getDealsById";
+import { GetContactById } from "@/actions/getContactById";
+import StepOneForm from "./StepOneForm";
 
-type Props = {
-  params: Promise<{ id: string; dealId: string }>;
-};
-const page = async ({ params }: Props) => {
-  const { dealId } = await params;
-  const dealData = getDealById(dealId);
-  console.log("Deal Data:", dealData);
-  return <div className="text-primary">Step one</div>;
-};
+interface Props {
+  params: { id: string; dealId: string };
+}
 
-export default page;
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+  const contactData = await GetContactById(id, true);
+
+  const initialData = {
+    yearOfConstruction: dealData?.properties?.year_of_construction || "",
+    insulationType: dealData?.properties?.insulation_type || "",
+    specificNeeds: dealData?.properties?.specific_needs?.split(";").filter(Boolean) || [],
+    otherSpecificNeed: dealData?.properties?.other_specific_need || "",
+    installationResponsible: dealData?.properties?.installation_responsible || "",
+  };
+
+  return (
+    <div className="p-4">
+      <StepOneForm dealId={dealId} contactId={id} initialData={initialData} />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import DocumentationContent from "@/components/Modals/TechnicalInformation/DocumentationContent";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+
+interface StepThreeFormProps {
+  dealId: string;
+  contactId: string;
+  initialData: any;
+}
+
+export default function StepThreeForm({ dealId, contactId, initialData }: StepThreeFormProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const handleComplete = async (_data: any) => {
+    await patchDealProperties(dealId, {
+      last_step: "step-4",
+    });
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-four`);
+  };
+
+  return (
+    <DocumentationContent
+      onComplete={handleComplete}
+      formRef={formRef}
+      initialData={initialData}
+      dealId={dealId}
+    />
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import DocumentationContent from "@/components/Modals/TechnicalInformation/DocumentationContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { Button } from "@/components/ui/button";
 
 interface StepThreeFormProps {
   dealId: string;
@@ -10,7 +11,11 @@ interface StepThreeFormProps {
   initialData: any;
 }
 
-export default function StepThreeForm({ dealId, contactId, initialData }: StepThreeFormProps) {
+export default function StepThreeForm({
+  dealId,
+  contactId,
+  initialData,
+}: StepThreeFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -21,12 +26,35 @@ export default function StepThreeForm({ dealId, contactId, initialData }: StepTh
     router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-four`);
   };
 
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(
+        new Event("submit", { cancelable: true, bubbles: true })
+      );
+    }
+  };
+
+  const handleBack = () => {
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-two`);
+  };
+
   return (
-    <DocumentationContent
-      onComplete={handleComplete}
-      formRef={formRef}
-      initialData={initialData}
-      dealId={dealId}
-    />
+    <div className="space-y-6">
+      <DocumentationContent
+        onComplete={handleComplete}
+        formRef={formRef}
+        initialData={initialData}
+        dealId={dealId}
+      />
+      <div className="flex justify-between mt-8 pt-4 border-t border-gray-200">
+        <Button type="button" variant="outline" onClick={handleBack}>
+          Back
+        </Button>
+
+        <Button type="button" onClick={handleSubmit}>
+          Save & Continue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/page.tsx
@@ -1,5 +1,28 @@
-const page = async () => {
-  return <div className="text-primary">Step three</div>;
-};
+import { getDealById } from "@/actions/deals/getDealsById";
+import { getFilesById } from "@/actions/deals/getFilesById";
+import StepThreeForm from "./StepThreeForm";
 
-export default page;
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+
+  let filesData: any[] = [];
+  if (dealData?.properties.complete_system_documentation) {
+    const { results } = await getFilesById(
+      dealData.properties.complete_system_documentation.split(";")
+    );
+    filesData = results;
+  }
+
+  const initialData = filesData.map((file: any) => ({
+    id: file.id,
+    name: file.name,
+    url: file.url,
+  }));
+
+  return (
+    <div className="p-4">
+      <StepThreeForm dealId={dealId} contactId={id} initialData={initialData} />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-three/page.tsx
@@ -2,8 +2,12 @@ import { getDealById } from "@/actions/deals/getDealsById";
 import { getFilesById } from "@/actions/deals/getFilesById";
 import StepThreeForm from "./StepThreeForm";
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
 
   let filesData: any[] = [];

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import { useRouter } from "next/navigation";
 import ZonesInformationContent from "@/components/Modals/TechnicalInformation/ZonesInformationContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { Button } from "@/components/ui/button";
 
 interface StepTwoFormProps {
   dealId: string;
@@ -10,7 +11,11 @@ interface StepTwoFormProps {
   initialData: any;
 }
 
-export default function StepTwoForm({ dealId, contactId, initialData }: StepTwoFormProps) {
+export default function StepTwoForm({
+  dealId,
+  contactId,
+  initialData,
+}: StepTwoFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
 
@@ -20,14 +25,40 @@ export default function StepTwoForm({ dealId, contactId, initialData }: StepTwoF
       zones_configuration: JSON.stringify(data.zones),
       last_step: "step-3",
     });
-    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-three`);
+    router.push(
+      `/forms/complete-system/${contactId}/deal/${dealId}/step-three`
+    );
+  };
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.dispatchEvent(
+        new Event("submit", { cancelable: true, bubbles: true })
+      );
+    }
+  };
+
+  const handleBack = () => {
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-one`);
   };
 
   return (
-    <ZonesInformationContent
-      onComplete={handleComplete}
-      initialData={initialData}
-      formRef={formRef}
-    />
+    <div className="space-y-6">
+      <ZonesInformationContent
+        onComplete={handleComplete}
+        initialData={initialData}
+        formRef={formRef}
+      />
+
+      {/* Botones de navegación */}
+      <div className="flex justify-between mt-8 pt-4 border-t border-gray-200">
+        <Button type="button" variant="outline" onClick={handleBack}>
+          Back
+        </Button>
+
+        <Button type="button" onClick={handleSubmit}>
+          Save & Continue
+        </Button>
+      </div>
+    </div>
   );
 }

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useRef } from "react";
+import { useRouter } from "next/navigation";
+import ZonesInformationContent from "@/components/Modals/TechnicalInformation/ZonesInformationContent";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+
+interface StepTwoFormProps {
+  dealId: string;
+  contactId: string;
+  initialData: any;
+}
+
+export default function StepTwoForm({ dealId, contactId, initialData }: StepTwoFormProps) {
+  const router = useRouter();
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  const handleComplete = async (data: any) => {
+    await patchDealProperties(dealId, {
+      number_of_zones: data.numberOfZones,
+      zones_configuration: JSON.stringify(data.zones),
+      last_step: "step-3",
+    });
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/step-three`);
+  };
+
+  return (
+    <ZonesInformationContent
+      onComplete={handleComplete}
+      initialData={initialData}
+      formRef={formRef}
+    />
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/page.tsx
@@ -1,5 +1,20 @@
-const page = async () => {
-  return <div className="text-primary">Step two</div>;
-};
+import { getDealById } from "@/actions/deals/getDealsById";
+import StepTwoForm from "./StepTwoForm";
 
-export default page;
+export default async function Page({ params }: { params: { id: string; dealId: string } }) {
+  const { id, dealId } = params;
+  const dealData = await getDealById(dealId, true);
+
+  const initialData = {
+    numberOfZones: dealData?.properties?.number_of_zones || "1",
+    zones: dealData?.properties?.zones_configuration
+      ? JSON.parse(dealData.properties.zones_configuration)
+      : [{ name: "", size: "", distribution: "" }],
+  };
+
+  return (
+    <div className="p-4">
+      <StepTwoForm dealId={dealId} contactId={id} initialData={initialData} />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-two/page.tsx
@@ -1,8 +1,12 @@
 import { getDealById } from "@/actions/deals/getDealsById";
 import StepTwoForm from "./StepTwoForm";
 
-export default async function Page({ params }: { params: { id: string; dealId: string } }) {
-  const { id, dealId } = params;
+type Props = {
+  params: Promise<{ id: string; dealId: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { id, dealId } = await params;
   const dealData = await getDealById(dealId, true);
 
   const initialData = {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,8 +1,8 @@
 export default function NotFound() {
   return (
     <div style={{ textAlign: "center", padding: "50px" }}>
-      <h1>404 - Página No Encontrada</h1>
-      <p>Lo sentimos, la página que buscas no existe.</p>
+      <h1>404 - Page Not Found</h1>
+      <p>Sorry, the page you are looking for does not exist.</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add client step forms for complete system workflow
- mirror modal steps on individual pages
- extend layout with extra navigation step
- provide simple review view

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862a6b023d48331b4bafb48eecb2d39