### PR TITLE
Implement items step for complete system quote

### DIFF
--- a/src/actions/contact/createCompleteSystemQuote.ts
+++ b/src/actions/contact/createCompleteSystemQuote.ts
@@ -1,0 +1,63 @@
+"use server";
+import { Product } from "@/types";
+import { createLineItems } from "./createLineItems";
+import { buildSimpleQuote } from "../quote/buildSimpleQuote";
+import { getHubspotOwnerIdSession } from "../user/getHubspotOwnerId";
+import { getHubspotOwnerId } from "../getOwnerId";
+import { getOwnerExtraData } from "../getOwnerExtraData";
+import { GetContactById } from "../getContactById";
+import { patchDealProperties } from "./patchDealProperties";
+
+interface CompleteSystemQuoteProps {
+  dealId: string;
+  contactId: string;
+  products: Product[];
+  onProgress?: (step: string, percentage: number) => void;
+}
+
+export const createCompleteSystemQuote = async ({
+  dealId,
+  contactId,
+  products,
+  onProgress,
+}: CompleteSystemQuoteProps) => {
+  try {
+    onProgress?.("Creating line items...", 20);
+    const lineItemsData = await createLineItems(dealId, products);
+
+    onProgress?.("Fetching contact data...", 30);
+    const contact = await GetContactById(contactId, true);
+
+    const userId = await getHubspotOwnerIdSession();
+    const ownerData = await getHubspotOwnerId(userId);
+    const { phone, jobtitle } = await getOwnerExtraData(ownerData.email);
+
+    onProgress?.("Building quote...", 80);
+    const quoteBuilded = await buildSimpleQuote(
+      contactId,
+      contact.properties.firstname,
+      contact.properties.lastname,
+      dealId,
+      ownerData.email,
+      ownerData.firstName,
+      ownerData.lastName,
+      phone,
+      jobtitle,
+      "",
+      lineItemsData.results
+    );
+
+    onProgress?.("Updating deal...", 95);
+    await patchDealProperties(dealId, {
+      quote_url: quoteBuilded.data,
+      last_step: "completed",
+    });
+
+    return { success: true, quoteUrl: quoteBuilded.data };
+  } catch (error) {
+    console.error("Error in createCompleteSystemQuote:", error);
+    throw new Error(
+      "Failed to create Complete System Quote: " + (error as Error).message
+    );
+  }
+};

--- a/src/app/api/generate/complete-system/route.ts
+++ b/src/app/api/generate/complete-system/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { createCompleteSystemQuote } from "@/actions/contact/createCompleteSystemQuote";
+import { Product } from "@/types";
+
+export async function POST(request: Request) {
+  const { dealId, contactId, products } = (await request.json()) as {
+    dealId: string;
+    contactId: string;
+    products: Product[];
+  };
+
+  const encoder = new TextEncoder();
+
+  const readable = new ReadableStream({
+    async start(controller) {
+      function send(event: string, payload: any) {
+        const data = JSON.stringify(payload);
+        controller.enqueue(encoder.encode(`event: ${event}\ndata: ${data}\n\n`));
+      }
+
+      try {
+        if (!dealId || !contactId || !products || products.length === 0) {
+          send("error", { error: "Missing data" });
+          return;
+        }
+
+        const result = await createCompleteSystemQuote({
+          dealId,
+          contactId,
+          products,
+          onProgress: (step, percentage) => send("progress", { step, percentage }),
+        });
+
+        send("complete", {
+          success: true,
+          redirect1: result.quoteUrl,
+          redirect2: `/contacts/${contactId}`,
+          contactId,
+        });
+      } catch (error) {
+        send("error", { error: error instanceof Error ? error.message : "Unknown error" });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new NextResponse(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/items/ItemsForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/items/ItemsForm.tsx
@@ -1,0 +1,141 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import ProductCard from "@/components/ProductCard";
+import { SideProductSheet } from "@/components/SideProductSheet";
+import { Product } from "@/types";
+import { createFormSubmitHandler } from "@/lib/sse";
+import { useToast } from "@/components/ui/use-toast";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { WheelProgress } from "@/components/ui/wheel-progress";
+
+interface ItemsFormProps {
+  contactId: string;
+  dealId: string;
+}
+
+export default function ItemsForm({ contactId, dealId }: ItemsFormProps) {
+  const [selectedProducts, setSelectedProducts] = useState<Product[]>([]);
+  const [totalPrice, setTotalPrice] = useState(0);
+  const [redirectOptions, setRedirectOptions] = useState<{ redirect1?: string; redirect2?: string } | null>(null);
+  const [showDialog, setShowDialog] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [currentProgress, setCurrentProgress] = useState(0);
+  const [currentStep, setCurrentStep] = useState("");
+  const { toast } = useToast();
+  const router = useRouter();
+
+  useEffect(() => {
+    const price = selectedProducts.reduce((acc, product) => {
+      const discounted = (product.price * (100 - (product.unitDiscount || 0))) / 100;
+      return acc + discounted * product.quantity;
+    }, 0);
+    setTotalPrice(price);
+  }, [selectedProducts]);
+
+  const handleRemoveProduct = (productId: string) => {
+    setSelectedProducts((prev) => prev.filter((p) => p.id !== productId));
+  };
+
+  const handleQuantity = (productId: string, action: string) => {
+    setSelectedProducts((prev) =>
+      prev.map((product) => {
+        if (product.id === productId) {
+          const newQty = action === "increase" ? product.quantity + 1 : product.quantity - 1;
+          return { ...product, quantity: Math.max(newQty, 1) };
+        }
+        return product;
+      })
+    );
+  };
+
+  const handleDiscount = (productId: string, discount: number) => {
+    setSelectedProducts((prev) =>
+      prev.map((product) => (product.id === productId ? { ...product, unitDiscount: discount } : product))
+    );
+  };
+
+  const handleFormSubmit = createFormSubmitHandler("/api/generate/complete-system", {
+    setIsSubmitting,
+    setHasError,
+    setIsComplete,
+    setCurrentProgress,
+    setCurrentStep,
+    setShowDialog,
+    setRedirectOptions,
+    toast,
+  });
+
+  return (
+    <>
+      <form
+        onSubmit={(e) => handleFormSubmit(e, { dealId, contactId, products: selectedProducts })}
+        className="flex flex-col gap-4"
+      >
+        <SideProductSheet
+          selectedProducts={selectedProducts as any}
+          setSelectedProducts={setSelectedProducts as any}
+        />
+        <ProductCard
+          selectedProducts={selectedProducts}
+          totalPrice={totalPrice}
+          onRemoveProduct={handleRemoveProduct}
+          handleQuantity={handleQuantity}
+          handleDiscount={handleDiscount}
+        />
+        <Button type="submit" disabled={isSubmitting} className="self-end">
+          {isSubmitting ? "Processing..." : "Generate Quote"}
+        </Button>
+      </form>
+      <Dialog open={showDialog} onOpenChange={setShowDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {!isComplete ? "Processing Quote" : hasError ? "Error Processing Quote" : "Quote Ready"}
+            </DialogTitle>
+            {!isComplete && (
+              <DialogDescription>Please wait while we process your quote...</DialogDescription>
+            )}
+            {isComplete && !hasError && (
+              <DialogDescription>Select an option to continue</DialogDescription>
+            )}
+          </DialogHeader>
+          {currentProgress > 0 && (
+            <div className="flex flex-col items-center gap-4 py-4">
+              <WheelProgress value={currentProgress} size="lg" />
+              <p className="text-center text-muted-foreground">{currentStep}</p>
+            </div>
+          )}
+          {isComplete && !hasError && (
+            <div className="flex flex-col gap-4">
+              <Button
+                onClick={() => {
+                  if (redirectOptions?.redirect1) window.open("http://" + redirectOptions.redirect1, "_blank");
+                }}
+              >
+                Go to quote page
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  if (redirectOptions?.redirect2) router.push(redirectOptions.redirect2);
+                }}
+              >
+                Back to main contact
+              </Button>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/items/page.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/items/page.tsx
@@ -1,0 +1,10 @@
+import ItemsForm from "./ItemsForm";
+
+export default async function Page({ params }: { params: Promise<{ id: string; dealId: string }> }) {
+  const { id, dealId } = await params;
+  return (
+    <div className="p-4">
+      <ItemsForm contactId={id} dealId={dealId} />
+    </div>
+  );
+}

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/layout.tsx
@@ -38,9 +38,9 @@ export default async function DealsLayout({ children, params }: Props) {
     },
 
     {
-      title: "Review",
-      route: "review",
-      link: `/forms/complete-system/${id}/deal/${dealId}/review`,
+      title: "Items",
+      route: "items",
+      link: `/forms/complete-system/${id}/deal/${dealId}/items`,
     },
   ];
 

--- a/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
@@ -34,9 +34,9 @@ export default function StepFiveForm({
       shipping_zip_code: data.shipping_zip_code,
       delivery_type: data.delivery_type,
       dropoff_condition: data.dropoff_condition,
-      last_step: "review",
+      last_step: "items",
     });
-    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/review`);
+    router.push(`/forms/complete-system/${contactId}/deal/${dealId}/items`);
   };
 
   const handleSubmit = () => {


### PR DESCRIPTION
## Summary
- add items step to complete system process
- create server action to build complete system quote and API route
- update navigation and shipping step to use new items step
- provide form and UI to select items and generate quote

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c043470c8331b5883029999b1a90