### PR TITLE
Update deal stage when meeting scheduled

### DIFF
--- a/src/app/forms/complete-system/[id]/deal/[dealId]/meeting/MeetingForm.tsx
+++ b/src/app/forms/complete-system/[id]/deal/[dealId]/meeting/MeetingForm.tsx
@@ -5,6 +5,7 @@ import { useMeetingLink } from "@/hooks/useMeetingLink";
 import MeetingModal from "@/components/Modals/LeadQualification/MeetingModal";
 import { Skeleton } from "@/components/ui/skeleton";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { dealStage } from "@/app/mydeals/utils";
 
 interface MeetingFormProps {
   dealId: string;
@@ -43,7 +44,10 @@ export default function MeetingForm({
 
   const handleComplete = async () => {
     try {
-      await patchDealProperties(dealId, { last_step: "meeting" });
+      await patchDealProperties(dealId, {
+        last_step: "meeting",
+        dealstage: dealStage["2nd meet: Quote Presentation & Close"],
+      });
     } catch (error) {
       console.error("Error updating deal after meeting:", error);
     }

--- a/src/components/Modals/TechnicalInformation/TechnicalInformationModal.tsx
+++ b/src/components/Modals/TechnicalInformation/TechnicalInformationModal.tsx
@@ -22,6 +22,7 @@ import { getFilesById } from "@/actions/deals/getFilesById";
 import MeetingModal from "../LeadQualification/MeetingModal";
 import { useMeetingLink } from "@/hooks/useMeetingLink";
 import { Skeleton } from "@/components/ui/skeleton";
+import { dealStage } from "@/app/mydeals/utils";
 import {
   convertFormToUpdateData,
   ZonesInformationFormValues,
@@ -350,6 +351,7 @@ export function TechnicalInformationModal({
         // Meeting step completed - no additional data to save
         await patchDealProperties(dealData.id, {
           last_step: currentStep,
+          dealstage: dealStage["2nd meet: Quote Presentation & Close"],
         });
       }
 


### PR DESCRIPTION
## Summary
- update meeting form to advance deal stage after booking
- sync TechnicalInformationModal meeting step to same deal stage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635543aeb08331bdb890ed601eeda1