### PR TITLE
Enable menu open on deal card click

### DIFF
--- a/src/app/mydeals/components/DealCardOptions.tsx
+++ b/src/app/mydeals/components/DealCardOptions.tsx
@@ -16,12 +16,16 @@ interface DealCardOptions {
   contactId: string;
   dealId: string;
   dealPipeline: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function DealCardOptions({
   contactId,
   dealId,
   dealPipeline,
+  open,
+  onOpenChange,
 }: DealCardOptions) {
   const [isDealModalOpen, setIsDealModalOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -30,18 +34,23 @@ export function DealCardOptions({
   const router = useRouter();
 
   const handleOpenDealModal = () => {
-    setIsDropdownOpen(false);
+    const closeMenu = onOpenChange ?? setIsDropdownOpen;
+    closeMenu(false);
     setIsDealModalOpen(true);
   };
 
   const handleOpenTechnicalInfoModal = () => {
-    setIsDropdownOpen(false);
+    const closeMenu = onOpenChange ?? setIsDropdownOpen;
+    closeMenu(false);
     setIsTechnicalInfoModalOpen(true);
   };
 
   return (
     <>
-      <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+      <DropdownMenu
+        open={open !== undefined ? open : isDropdownOpen}
+        onOpenChange={onOpenChange ?? setIsDropdownOpen}
+      >
         <DropdownMenuTrigger asChild>
           <Button variant="ghost" className="h-8 w-8 p-0">
             <span className="sr-only">Open menu</span>

--- a/src/app/mydeals/deal-kanban-card.tsx
+++ b/src/app/mydeals/deal-kanban-card.tsx
@@ -1,5 +1,6 @@
 import { Card, CardContent } from "@/components/ui/card";
 import { Deal } from "./deals";
+import { useState } from "react";
 import {
   calculateDaysRemaining,
   calculateDealProgress,
@@ -15,10 +16,9 @@ import { DealCardOptions } from "./components/DealCardOptions";
 
 interface DealCardProps {
   deal: Deal;
-  onSelect?: (id: string) => void;
 }
 
-export const DealCard = ({ deal, onSelect }: DealCardProps) => {
+export const DealCard = ({ deal }: DealCardProps) => {
   const contact = deal.contacts[0];
   const dealPipeline = deal.properties.pipeline;
 
@@ -34,20 +34,21 @@ export const DealCard = ({ deal, onSelect }: DealCardProps) => {
     return "bg-red-500";
   };
 
-  const handleSelect = () => {
-    onSelect?.(deal.id);
+  const [optionsOpen, setOptionsOpen] = useState(false);
+  const handleCardClick = () => {
+    setOptionsOpen(true);
   };
 
   return (
     <Card
       className="mb-3 hover:shadow-md transition-shadow cursor-pointer"
-      onClick={handleSelect}
+      onClick={handleCardClick}
       tabIndex={0}
       role="button"
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          handleSelect();
+          handleCardClick();
         }
       }}
     >
@@ -62,6 +63,8 @@ export const DealCard = ({ deal, onSelect }: DealCardProps) => {
                 contactId={contact.id}
                 dealId={deal.id}
                 dealPipeline={dealPipeline}
+                open={optionsOpen}
+                onOpenChange={setOptionsOpen}
               />
             </div>
             <div className="flex items-center gap-1 mt-1">

--- a/src/app/mydeals/deals-kanban-board.tsx
+++ b/src/app/mydeals/deals-kanban-board.tsx
@@ -53,8 +53,6 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
     useState<string>(mostDealsPipeline);
   const [timeFilter, setTimeFilter] = useState<string>("all");
   const [viewMode, setViewMode] = useState<"column" | "list">("column");
-  const [selectedDealId, setSelectedDealId] = useState<string | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Define the order of deal stages
   const dealStageOrder = useMemo(() => {
@@ -301,26 +299,10 @@ const DealsKanbanBoard = ({ deals }: DealsKanbanBoardProps) => {
       {viewMode === "list" && (
         <div className="grid gap-4">
           {filteredDeals.map((deal) => (
-            <DealCard
-              key={deal.id}
-              deal={deal}
-              onSelect={(id) => {
-                setSelectedDealId(id);
-                setIsModalOpen(true);
-              }}
-            />
+            <DealCard key={deal.id} deal={deal} />
           ))}
         </div>
       )}
-
-      {/* <DealModal
-        dealId={selectedDealId}
-        isOpen={isModalOpen}
-        onClose={() => {
-          setIsModalOpen(false);
-          setSelectedDealId(null);
-        }}
-      /> */}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- trigger DealCardOptions menu when clicking a card
- allow DealCardOptions dropdown to be externally controlled
- simplify DealsKanbanBoard by removing unused selection logic

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635f9c5efc8331b83e39590433e56f