### PR TITLE
Add deal lost modal

### DIFF
--- a/src/app/mydeals/components/DealCardOptions.tsx
+++ b/src/app/mydeals/components/DealCardOptions.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { MoreHorizontal, Eye, FileText } from "lucide-react";
 import { TechnicalInformationModal } from "@/components/Modals/TechnicalInformation/TechnicalInformationModal";
 import { DealModal } from "@/components/Modals/Deal/DealModal";
+import DealLostModal from "@/components/Modals/Deal/DealLostModal";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 interface DealCardOptions {
@@ -27,6 +28,7 @@ export function DealCardOptions({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isTechnicalInfoModalOpen, setIsTechnicalInfoModalOpen] =
     useState(false);
+  const [isLostModalOpen, setIsLostModalOpen] = useState(false);
   const router = useRouter();
 
   const handleOpenDealModal = () => {
@@ -37,6 +39,11 @@ export function DealCardOptions({
   const handleOpenTechnicalInfoModal = () => {
     setIsDropdownOpen(false);
     setIsTechnicalInfoModalOpen(true);
+  };
+
+  const handleOpenLostModal = () => {
+    setIsDropdownOpen(false);
+    setIsLostModalOpen(true);
   };
 
   return (
@@ -67,6 +74,12 @@ export function DealCardOptions({
             </DropdownMenuItem>
           )}
           <DropdownMenuItem
+            onSelect={(e) => e.preventDefault()}
+            onClick={handleOpenLostModal}
+          >
+            <span>Mark as Lost</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
             className="flex items-center justify-center bg-black text-white"
             onSelect={(e) => {
               e.preventDefault();
@@ -88,6 +101,13 @@ export function DealCardOptions({
         isOpen={isTechnicalInfoModalOpen}
         onClose={() => setIsTechnicalInfoModalOpen(false)}
         dealId={dealId}
+      />
+
+      <DealLostModal
+        isOpen={isLostModalOpen}
+        onClose={() => setIsLostModalOpen(false)}
+        dealId={dealId}
+        pipeline={dealPipeline}
       />
     </>
   );

--- a/src/components/Modals/Deal/DealLostModal.tsx
+++ b/src/components/Modals/Deal/DealLostModal.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { lostDealSchema, LostDealFormValues } from "@/schemas/lostDealSchema";
+import { patchDealProperties } from "@/actions/contact/patchDealProperties";
+import { closeLostReasons } from "@/types";
+import { dealStage } from "@/app/mydeals/utils";
+import { useState } from "react";
+
+interface DealLostModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  dealId: string;
+  pipeline: string;
+}
+
+export function DealLostModal({ isOpen, onClose, dealId, pipeline }: DealLostModalProps) {
+  const { toast } = useToast();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const form = useForm<LostDealFormValues>({
+    resolver: zodResolver(lostDealSchema),
+    defaultValues: {
+      closed_lost_reason: "Too High Pricing",
+      lost_reason_detail: "",
+    },
+  });
+
+  const onSubmit = async (data: LostDealFormValues) => {
+    setIsSaving(true);
+    try {
+      await patchDealProperties(dealId, {
+        closed_lost_reason: data.closed_lost_reason as any,
+        lost_reason_detail: data.lost_reason_detail ?? "",
+        dealstage:
+          pipeline === "732661879"
+            ? dealStage["Closed Lost - Complete System"]
+            : dealStage["Closed Lost"],
+      });
+      toast({ title: "Deal updated", description: "Deal marked as lost." });
+      onClose();
+    } catch (error) {
+      toast({ title: "Error", description: "Failed to update deal", variant: "destructive" });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent aria-describedby={undefined} className="sm:max-w-[450px]">
+        <DialogHeader>
+          <DialogTitle>Mark Deal as Lost</DialogTitle>
+        </DialogHeader>
+        <div className="py-4 space-y-6">
+          <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+            <p className="text-sm text-muted-foreground">
+              Please select the reason why this deal was lost.
+            </p>
+          </div>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+              <FormField
+                control={form.control}
+                name="closed_lost_reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Lost Reason</FormLabel>
+                    <FormControl>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select a reason" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {closeLostReasons.map((reason) => (
+                            <SelectItem key={reason.value} value={reason.value}>
+                              {reason.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {form.watch("closed_lost_reason") === "Other" && (
+                <FormField
+                  control={form.control}
+                  name="lost_reason_detail"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Reason Detail</FormLabel>
+                      <FormControl>
+                        <Textarea className="resize-none" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+
+              <div className="flex justify-end gap-2">
+                <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                  Cancel
+                </Button>
+                <Button type="submit" disabled={isSaving} variant="destructive">
+                  {isSaving ? "Saving..." : "Confirm"}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default DealLostModal;

--- a/src/schemas/lostDealSchema.ts
+++ b/src/schemas/lostDealSchema.ts
@@ -1,0 +1,21 @@
+import z from "zod";
+import { closeLostReasonValues } from "@/types";
+
+export const lostDealSchema = z
+  .object({
+    closed_lost_reason: z.enum(closeLostReasonValues as [string, ...string[]], {
+      errorMap: () => ({ message: "Select a reason" }),
+    }),
+    lost_reason_detail: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.closed_lost_reason === "Other" && !data.lost_reason_detail?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Please provide details",
+        path: ["lost_reason_detail"],
+      });
+    }
+  });
+
+export type LostDealFormValues = z.infer<typeof lostDealSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -552,3 +552,20 @@ export const disqualificationReason = [
 export const disqualificationReasonValues = disqualificationReason.map(
   (type) => type.value
 );
+
+export const closeLostReasons = [
+  { label: "Too High Pricing", value: "Too High Pricing" },
+  { label: "Budget Constraints", value: "Budget Constraints" },
+  { label: "Product Unfit", value: "Product Unfit" },
+  { label: "Competition", value: "Competition" },
+  { label: "Decision Delay", value: "Decision Delay" },
+  { label: "Poor Timing", value: "Poor Timing" },
+  { label: "Ineffective Sales Process", value: "Ineffective Sales Process" },
+  { label: "Customer Service Issues", value: "Customer Service Issues" },
+  { label: "Lost Contact", value: "Lost Contact" },
+  { label: "External Factors", value: "External Factors" },
+  { label: "Cancelled Abandoned Checkout", value: "Cancelled Abandoned Checkout" },
+  { label: "Other", value: "Other" },
+];
+
+export const closeLostReasonValues = closeLostReasons.map((reason) => reason.value);


### PR DESCRIPTION
## Summary
- add Close Lost options to types list
- add lost deal schema with validation
- add DealLostModal with form to update loss reason
- integrate modal into DealCardOptions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9494b03483318bb01300055b2197