### PR TITLE
Improve deal modal details

### DIFF
--- a/src/actions/deals/createDealNote.ts
+++ b/src/actions/deals/createDealNote.ts
@@ -1,0 +1,40 @@
+"use server";
+import { revalidateTag } from "next/cache";
+
+export async function createDealNote(dealId: string, body: string) {
+  const URL = `https://api.hubapi.com/engagements/v1/engagements`;
+
+  try {
+    const response = await fetch(URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.HUBSPOT_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        engagement: {
+          active: true,
+          type: "NOTE",
+          timestamp: Date.now(),
+        },
+        associations: {
+          dealIds: [parseInt(dealId)],
+        },
+        metadata: {
+          body,
+        },
+      }),
+    });
+
+    if (response.ok) {
+      revalidateTag("engagements");
+      return await response.json();
+    } else {
+      const data = await response.json();
+      return { error: "Failed to create note", details: data };
+    }
+  } catch (error) {
+    console.error("Error creating deal note:", error);
+    return null;
+  }
+}

--- a/src/components/Modals/Deal/EngagementsTab.tsx
+++ b/src/components/Modals/Deal/EngagementsTab.tsx
@@ -8,41 +8,117 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { getEngagementIcon } from "../Contact/utils";
 import { getDealEngagements } from "@/actions/deals/getDealEngagements";
+import { createDealNote } from "@/actions/deals/createDealNote";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { Form, FormField, FormItem, FormControl, FormLabel, FormMessage } from "@/components/ui/form";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { useSession } from "next-auth/react";
 
 interface EngagementsTabProps {
   dealId: string;
 }
 
+const noteFormSchema = z.object({
+  content: z
+    .string()
+    .min(1, "Note content is required")
+    .max(10240, { message: "Content cannot exceed 10,240 characters." }),
+});
+
+type NoteFormValues = z.infer<typeof noteFormSchema>;
+
 const EngagementsTab = ({ dealId }: EngagementsTabProps) => {
   const [engagements, setEngagements] = useState<Engagement[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const session = useSession();
+
+  const userName = session.data?.user.name;
+
+  const form = useForm<NoteFormValues>({
+    resolver: zodResolver(noteFormSchema),
+    defaultValues: { content: "" },
+  });
+
+  const onSubmit = async (data: NoteFormValues) => {
+    setIsSubmitting(true);
+    try {
+      const noteWithName = `${userName ? `${userName}:\n` : ""}${data.content}`;
+      await createDealNote(dealId, noteWithName);
+      form.reset();
+      await fetchEngagements();
+    } catch (err) {
+      console.error("Error creating note:", err);
+      setError("Failed to create note");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const fetchEngagements = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getDealEngagements(dealId);
+      setEngagements(
+        (data?.results || []).sort(
+          (a: Engagement, b: Engagement) =>
+            b.engagement.timestamp - a.engagement.timestamp
+        )
+      );
+    } catch (err) {
+      console.error("Error fetching engagements:", err);
+      setError("Failed to load engagements");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    const fetchEngagements = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await getDealEngagements(dealId);
-        setEngagements(
-          (data?.results || []).sort(
-            (a: Engagement, b: Engagement) =>
-              b.engagement.timestamp - a.engagement.timestamp
-          )
-        );
-      } catch (err) {
-        console.error("Error fetching engagements:", err);
-        setError("Failed to load engagements");
-      } finally {
-        setLoading(false);
-      }
-    };
-
     fetchEngagements();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dealId]);
 
   return (
-    <TabsContent value="engagements" className="mt-4">
+    <TabsContent value="engagements" className="mt-4 space-y-4">
+      <Form {...form}>
+        <FormField
+          control={form.control}
+          name="content"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>New Note</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Add a note about this deal..."
+                  className="min-h-[80px] resize-none"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button
+          type="button"
+          className="w-full mt-2"
+          disabled={isSubmitting}
+          onClick={form.handleSubmit(onSubmit)}
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Adding Note...
+            </>
+          ) : (
+            "Add Note"
+          )}
+        </Button>
+      </Form>
+
       {loading ? (
         <div className="min-h-[200px] flex flex-col items-center justify-center gap-2">
           <Loader2 className="h-8 w-8 animate-spin text-primary" />

--- a/src/components/Modals/Deal/InfoTab.tsx
+++ b/src/components/Modals/Deal/InfoTab.tsx
@@ -2,7 +2,10 @@
 
 import { TabsContent } from "@/components/ui/tabs";
 import { Deal } from "@/types/dealTypes";
-import { getDealStageLabel, getPipelineLabel } from "@/app/mydeals/utils";
+import {
+  getDealStageLabel,
+  getPipelineLabel,
+} from "@/app/mydeals/utils";
 
 interface InfoTabProps {
   deal: Deal;
@@ -11,6 +14,9 @@ interface InfoTabProps {
 const InfoTab = ({ deal }: InfoTabProps) => {
   const { dealname, amount, dealstage, pipeline, createdate, closedate } =
     deal.properties;
+  const pipelineLabel = getPipelineLabel(pipeline || "");
+  const isCompleteSystem = pipelineLabel === "Mbtek - Complete System";
+  const isInstantQuote = pipelineLabel === "Mbtek - Instant Quote";
 
   const formatCurrency = (value: number | string | undefined) => {
     if (!value) return "$0.00";
@@ -57,6 +63,60 @@ const InfoTab = ({ deal }: InfoTabProps) => {
           <span className="text-sm text-muted-foreground">Close Date</span>
           <span className="text-sm font-medium">{formatDate(closedate)}</span>
         </div>
+
+        {isCompleteSystem && (
+          <>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Year Built</span>
+              <span className="text-sm font-medium">
+                {deal.properties.year_of_construction || "N/A"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Insulation</span>
+              <span className="text-sm font-medium">
+                {deal.properties.insulation_type || "N/A"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Installation</span>
+              <span className="text-sm font-medium">
+                {deal.properties.installation_responsible || "N/A"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Specific Needs</span>
+              <span className="text-sm font-medium">
+                {deal.properties.specific_needs
+                  ? deal.properties.specific_needs.split(";").join(", ")
+                  : "N/A"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Zones</span>
+              <span className="text-sm font-medium">
+                {deal.properties.number_of_zones || "N/A"}
+              </span>
+            </div>
+          </>
+        )}
+
+        {isInstantQuote && (
+          <>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Billing Email</span>
+              <span className="text-sm font-medium">
+                {deal.properties.billing_email || "N/A"}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1">
+              <span className="text-sm text-muted-foreground">Billing Phone</span>
+              <span className="text-sm font-medium">
+                {deal.properties.billing_phone || "N/A"}
+              </span>
+            </div>
+          </>
+        )}
       </div>
     </TabsContent>
   );

--- a/src/components/Modals/Deal/LineItemsTab.tsx
+++ b/src/components/Modals/Deal/LineItemsTab.tsx
@@ -5,13 +5,7 @@ import { TabsContent } from "@/components/ui/tabs";
 import { LineItem } from "@/types/dealTypes";
 
 import { Loader2, Package } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import LineItemCard from "@/components/LineItemCard";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { getDealLineItems } from "@/actions/deals/getDealLineItems";
 
@@ -19,14 +13,6 @@ interface LineItemsTabProps {
   dealId: string;
 }
 
-const formatCurrency = (value: string | number | undefined) => {
-  if (!value) return "$0.00";
-  const num = typeof value === "string" ? parseFloat(value) : value;
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-  }).format(num);
-};
 
 const LineItemsTab = ({ dealId }: LineItemsTabProps) => {
   const [items, setItems] = useState<LineItem[]>([]);
@@ -68,37 +54,7 @@ const LineItemsTab = ({ dealId }: LineItemsTabProps) => {
         <ScrollArea className="h-[390px] pr-2">
           <div className="space-y-4">
             {items.map((item) => (
-              <Card key={item.id} className="overflow-hidden">
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium">
-                    {item.properties.name}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pb-2">
-                  <div className="grid grid-cols-3 gap-4 text-sm">
-                    <div>
-                      <span className="text-muted-foreground">Qty:</span>{" "}
-                      {item.properties.quantity}
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Price:</span>{" "}
-                      {formatCurrency(item.properties.price)}
-                    </div>
-                    <div>
-                      <span className="text-muted-foreground">Total:</span>{" "}
-                      {formatCurrency(
-                        parseFloat(item.properties.price) *
-                          parseFloat(item.properties.quantity)
-                      )}
-                    </div>
-                  </div>
-                </CardContent>
-                <CardFooter className="bg-muted/30 py-2 flex justify-between">
-                  <span className="text-xs text-muted-foreground">
-                    ID: {item.id}
-                  </span>
-                </CardFooter>
-              </Card>
+              <LineItemCard key={item.id} lineItem={item} />
             ))}
           </div>
         </ScrollArea>


### PR DESCRIPTION
## Summary
- show more deal info depending on pipeline
- display line items with a nicer card layout
- allow notes to be added from the engagements tab
- support creating deal notes with a new server action

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a9d37f430833194fe9fef7eb2aa75