### PR TITLE
Add loading spinners and skeletons to deal/quote steps

### DIFF
--- a/src/app/deals/complete-system/[id]/deal/[dealId]/meeting/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/meeting/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-five/StepFiveForm.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import { BillingFormValues } from "@/types/complete-system/billingTypes";
 import {
   convertShippingFormToUpdateData,
@@ -25,12 +26,15 @@ export default function StepFiveForm({
 }: StepFiveFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleComplete = async (data: ShippingFormValues) => {
+    setLoading(true);
     await patchDealProperties(
       dealId,
       convertShippingFormToUpdateData(data, "meeting")
     );
+    setLoading(false);
     router.push(`/deals/complete-system/${contactId}/deal/${dealId}/meeting`);
   };
 
@@ -59,7 +63,8 @@ export default function StepFiveForm({
           Back
         </Button>
 
-        <Button type="button" onClick={handleSubmit}>
+        <Button type="button" onClick={handleSubmit} disabled={loading}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Save & Continue
         </Button>
       </div>

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-five/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-five/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-four/StepFourForm.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import QuoteBillingContent from "@/components/Modals/TechnicalInformation/QuoteBillingContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
   BillingFormValues,
   convertBillingFormToUpdateData,
@@ -22,12 +23,15 @@ export default function StepFourForm({
 }: StepFourFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleComplete = async (data: BillingFormValues) => {
+    setLoading(true);
     await patchDealProperties(
       dealId,
       convertBillingFormToUpdateData(data, "step-5")
     );
+    setLoading(false);
     router.push(`/deals/complete-system/${contactId}/deal/${dealId}/step-five`);
   };
 
@@ -58,7 +62,8 @@ export default function StepFourForm({
           Back
         </Button>
 
-        <Button type="button" onClick={handleSubmit}>
+        <Button type="button" onClick={handleSubmit} disabled={loading}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Save & Continue
         </Button>
       </div>

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-four/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-four/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-one/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-one/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-three/StepThreeForm.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import DocumentationContent from "@/components/Modals/TechnicalInformation/DocumentationContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 
 interface StepThreeFormProps {
   dealId: string;
@@ -18,11 +19,14 @@ export default function StepThreeForm({
 }: StepThreeFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleComplete = async (_data: any) => {
+    setLoading(true);
     await patchDealProperties(dealId, {
       last_step: "step-4",
     });
+    setLoading(false);
     router.push(`/deals/complete-system/${contactId}/deal/${dealId}/step-four`);
   };
 
@@ -51,7 +55,8 @@ export default function StepThreeForm({
           Back
         </Button>
 
-        <Button type="button" onClick={handleSubmit}>
+        <Button type="button" onClick={handleSubmit} disabled={loading}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Save & Continue
         </Button>
       </div>

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-three/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-three/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-two/StepTwoForm.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import ZonesInformationContent from "@/components/Modals/TechnicalInformation/ZonesInformationContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
   convertFormToUpdateData,
   ZonesInformationFormValues,
@@ -22,9 +23,12 @@ export default function StepTwoForm({
 }: StepTwoFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleComplete = async (data: ZonesInformationFormValues) => {
+    setLoading(true);
     await patchDealProperties(dealId, convertFormToUpdateData(data, "step-3"));
+    setLoading(false);
     router.push(
       `/deals/complete-system/${contactId}/deal/${dealId}/step-three`
     );
@@ -55,7 +59,8 @@ export default function StepTwoForm({
           Back
         </Button>
 
-        <Button type="button" onClick={handleSubmit}>
+        <Button type="button" onClick={handleSubmit} disabled={loading}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Save & Continue
         </Button>
       </div>

--- a/src/app/deals/complete-system/[id]/deal/[dealId]/step-two/loading.tsx
+++ b/src/app/deals/complete-system/[id]/deal/[dealId]/step-two/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/quote/[dealId]/step-one/loading.tsx
+++ b/src/app/deals/complete-system/[id]/quote/[dealId]/step-one/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/complete-system/[id]/quote/[dealId]/step-two/loading.tsx
+++ b/src/app/deals/complete-system/[id]/quote/[dealId]/step-two/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/quick-quote/[id]/quote/[dealId]/review/loading.tsx
+++ b/src/app/deals/quick-quote/[id]/quote/[dealId]/review/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/quick-quote/[id]/quote/[dealId]/step-one/StepOneQuickQuoteForm.tsx
+++ b/src/app/deals/quick-quote/[id]/quote/[dealId]/step-one/StepOneQuickQuoteForm.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import QuoteBillingContent from "@/components/Modals/TechnicalInformation/QuoteBillingContent";
 import { patchDealProperties } from "@/actions/contact/patchDealProperties";
 import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
 import {
   BillingFormValues,
   convertBillingFormToUpdateData,
@@ -22,12 +23,15 @@ export default function StepOneQuickQuoteForm({
 }: StepOneQuickQuoteFormProps) {
   const router = useRouter();
   const formRef = useRef<HTMLFormElement | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const handleComplete = async (data: BillingFormValues) => {
+    setLoading(true);
     await patchDealProperties(
       dealId,
       convertBillingFormToUpdateData(data, "step-two")
     );
+    setLoading(false);
     router.push(`/deals/quick-quote/${contactId}/quote/${dealId}/step-two`);
   };
 
@@ -47,7 +51,8 @@ export default function StepOneQuickQuoteForm({
         formRef={formRef}
       />
       <div className="flex justify-end mt-8 pt-4 border-t border-gray-200">
-        <Button type="button" onClick={handleSubmit}>
+        <Button type="button" onClick={handleSubmit} disabled={loading}>
+          {loading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
           Save & Continue
         </Button>
       </div>

--- a/src/app/deals/quick-quote/[id]/quote/[dealId]/step-one/loading.tsx
+++ b/src/app/deals/quick-quote/[id]/quote/[dealId]/step-one/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/deals/quick-quote/[id]/quote/[dealId]/step-two/loading.tsx
+++ b/src/app/deals/quick-quote/[id]/quote/[dealId]/step-two/loading.tsx
@@ -1,0 +1,13 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-4">
+      <Skeleton className="h-10 w-48" />
+      <Skeleton className="h-[400px] w-full" />
+      <div className="flex justify-center items-center h-20">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500"></div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add spinner behavior to deal and quote step forms
- provide loading skeletons for each step page to indicate loading state

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687116fc64f48331a50f592a62d4b552