### PR TITLE
Allow admin views via hubspotId param

### DIFF
--- a/src/actions/activities/leadsBatchActivities.ts
+++ b/src/actions/activities/leadsBatchActivities.ts
@@ -308,9 +308,10 @@ async function getOwnerEngagements(
 // PUBLIC WRAPPER -----------------------------------------------------------
 export async function getLeadsBatchActivities(
   timeRange: "weekly" | "monthly" | "allTime" = "weekly",
-  after?: string
+  after?: string,
+  hubspotOwnerId?: string
 ) {
-  const ownerId = await getHubspotOwnerIdSession();
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   //const ownerId = "719106449"; // Byron (test)
   return getOwnerEngagements(ownerId, timeRange, after);
 }

--- a/src/actions/hubspot/analyticsData.ts
+++ b/src/actions/hubspot/analyticsData.ts
@@ -10,9 +10,10 @@ export type ContactLeadInfo = {
 
 export async function getContactsAndLeadsInRange(
   fromISO: string,
-  toISO: string
+  toISO: string,
+  hubspotOwnerId?: string
 ) {
-  const ownerId = await getHubspotOwnerIdSession();
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   const contacts: ContactLeadInfo[] = [];
   let after: string | undefined;
   do {
@@ -55,8 +56,12 @@ export async function getContactsAndLeadsInRange(
 
 export type DealInfo = { createdate: string };
 
-export async function getDealsInRange(fromISO: string, toISO: string) {
-  const ownerId = await getHubspotOwnerIdSession();
+export async function getDealsInRange(
+  fromISO: string,
+  toISO: string,
+  hubspotOwnerId?: string
+) {
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   const deals: DealInfo[] = [];
   let after: string | undefined;
 
@@ -106,9 +111,10 @@ export type QualificationInfo = { createdate: string; diffMs: number };
 
 export async function getQualificationTimesInRange(
   fromISO: string,
-  toISO: string
+  toISO: string,
+  hubspotOwnerId?: string
 ) {
-  const ownerId = await getHubspotOwnerIdSession();
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   const ids: string[] = [];
   let after: string | undefined;
 

--- a/src/actions/hubspot/dealsCount.ts
+++ b/src/actions/hubspot/dealsCount.ts
@@ -51,8 +51,12 @@ async function dealsCount(
   }
 }
 
-export async function getDealsCount(fromDate?: string, toDate?: string) {
-  const userId = await getHubspotOwnerIdSession();
+export async function getDealsCount(
+  fromDate?: string,
+  toDate?: string,
+  hubspotOwnerId?: string
+) {
+  const userId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   //const managerIdTest = "719106449"; // Byron
   return dealsCount(userId, fromDate, toDate);
 }

--- a/src/actions/hubspot/leadsCount.ts
+++ b/src/actions/hubspot/leadsCount.ts
@@ -51,8 +51,12 @@ async function leadsCount(
   }
 }
 
-export async function getLeadsCount(fromDate?: string, toDate?: string) {
-  const userId = await getHubspotOwnerIdSession();
+export async function getLeadsCount(
+  fromDate?: string,
+  toDate?: string,
+  hubspotOwnerId?: string
+) {
+  const userId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   // const managerIdTest = "719106449"; // Byron
   return leadsCount(userId, fromDate, toDate);
 }

--- a/src/actions/hubspot/qualifiedLeads.ts
+++ b/src/actions/hubspot/qualifiedLeads.ts
@@ -148,8 +148,11 @@ async function leadsQualified(userId: string, timeRange: string = "weekly") {
   }
 }
 
-export async function getQualifiedLeads(timeRange: string = "weekly") {
-  const userId = await getHubspotOwnerIdSession();
+export async function getQualifiedLeads(
+  timeRange: string = "weekly",
+  hubspotOwnerId?: string
+) {
+  const userId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   console.log("userId", userId);
   // const userId = "719106449"; // Byron
   const leads = await leadsQualified(userId, timeRange);

--- a/src/actions/searchOwnedContacts.ts
+++ b/src/actions/searchOwnedContacts.ts
@@ -127,8 +127,11 @@ async function getContactsBatch(contactIds: string[]) {
   }
 }
 
-export async function getContactsByOwnerId(after?: string) {
-  const userId = await getHubspotOwnerIdSession();
+export async function getContactsByOwnerId(
+  after?: string,
+  hubspotOwnerId?: string
+) {
+  const userId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   //const managerIdTest = "719106449";
 
   // Step 1: Get contact IDs

--- a/src/actions/searchOwnerDeals.ts
+++ b/src/actions/searchOwnerDeals.ts
@@ -184,8 +184,8 @@ export async function searchOwnerDeals(ownerId: string): Promise<Deal[]> {
   }
 }
 
-export async function getDealsByUserId() {
-  const userId = await getHubspotOwnerIdSession();
+export async function getDealsByUserId(hubspotOwnerId?: string) {
+  const userId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   //const userId = "79900767"; // Brian test
   return searchOwnerDeals(userId);
 }

--- a/src/actions/searchOwnerMeetings.ts
+++ b/src/actions/searchOwnerMeetings.ts
@@ -232,8 +232,8 @@ export async function searchOwnerMeetings(ownerId: string) {
 // ---------------------------------------------------------------------------
 // Utility: same wrapper you already expose
 // ---------------------------------------------------------------------------
-export async function getAllOwnersMeetings() {
-  const ownerId = await getHubspotOwnerIdSession();
+export async function getAllOwnersMeetings(hubspotOwnerId?: string) {
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
   // const ownerId = "79900767";
   return searchOwnerMeetings(ownerId);
 }

--- a/src/actions/tasks/getIncompleteTasks.ts
+++ b/src/actions/tasks/getIncompleteTasks.ts
@@ -23,10 +23,12 @@ const hubFetch = (url: string, init: RequestInit = {}) =>
 
 const taskProperties = ["hs_task_subject", "hs_task_status"];
 
-export async function getIncompleteTasks(): Promise<Task[]> {
+export async function getIncompleteTasks(
+  hubspotOwnerId?: string
+): Promise<Task[]> {
   if (!process.env.HUBSPOT_API_KEY) throw new Error("Missing HUBSPOT_API_KEY");
 
-  const ownerId = await getHubspotOwnerIdSession();
+  const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
 
   const searchBody = {
     properties: taskProperties,

--- a/src/actions/tasks/userBatchTasks.ts
+++ b/src/actions/tasks/userBatchTasks.ts
@@ -204,10 +204,11 @@ export async function getUserBatchTasks(
   timeRange: "daily" | "weekly" | "monthly" = "weekly",
   after?: string,
   fromDate?: string,
-  toDate?: string
+  toDate?: string,
+  hubspotOwnerId?: string
 ) {
   try {
-    const ownerId = await getHubspotOwnerIdSession();
+    const ownerId = hubspotOwnerId ?? (await getHubspotOwnerIdSession());
     //const ownerId = "719106449"; // Byron
     return getOwnerTasks(ownerId, timeRange, after, fromDate, toDate);
   } catch (error) {

--- a/src/app/active-qualifications/page.tsx
+++ b/src/app/active-qualifications/page.tsx
@@ -5,6 +5,7 @@ import StartQualificationModal from "@/components/LeadsQualifier/StartQualificat
 type SearchParams = {
   timeRange?: "weekly" | "monthly" | "allTime";
   startQualification?: string;
+  hubspotId?: string;
 };
 
 export default async function Page({
@@ -22,7 +23,10 @@ export default async function Page({
       {/* Trigger modal when URL contains startQualification */}
       <StartQualificationModal />
       <div className="w-full pr-4">
-        <LeadsQualifiedList searchParams={params} />
+        <LeadsQualifiedList
+          searchParams={params}
+          hubspotId={params.hubspotId}
+        />
       </div>
     </div>
   );

--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -42,10 +42,12 @@ async function AnalyticsPage({ searchParams }: { searchParams: SearchParams }) {
   const fullFrom = previousFrom.toISOString();
   const fullTo = dateRange.toISO;
 
+  const hubspotId = typeof params.hubspotId === "string" ? params.hubspotId : undefined;
+
   const [contactsLeads, dealsData, qtimes] = await Promise.all([
-    getContactsAndLeadsInRange(fullFrom, fullTo),
-    getDealsInRange(fullFrom, fullTo),
-    getQualificationTimesInRange(fullFrom, fullTo),
+    getContactsAndLeadsInRange(fullFrom, fullTo, hubspotId),
+    getDealsInRange(fullFrom, fullTo, hubspotId),
+    getQualificationTimesInRange(fullFrom, fullTo, hubspotId),
   ]);
 
   const isCurrent = (d: string) =>

--- a/src/app/engagements/page.tsx
+++ b/src/app/engagements/page.tsx
@@ -4,6 +4,7 @@ import PageHeader from "@/components/PageHeader";
 type SearchParams = {
   timeRange?: "weekly" | "monthly" | "allTime";
   filter?: string;
+  hubspotId?: string;
 };
 
 export default async function Page({
@@ -19,7 +20,10 @@ export default async function Page({
         subtitle="Manage your lead's engagements and activities"
       />
       <div className="w-full pr-4">
-        <LeadsActivitiesList searchParams={params} />
+        <LeadsActivitiesList
+          searchParams={params}
+          hubspotId={params.hubspotId}
+        />
       </div>
     </div>
   );

--- a/src/app/my-contacts/contacts-table.tsx
+++ b/src/app/my-contacts/contacts-table.tsx
@@ -88,7 +88,7 @@ const OwnedContactsTable = ({
     } finally {
       setIsLoading(false);
     }
-  }, [currentAfter, isLoading, hasMore]);
+  }, [currentAfter, isLoading, hasMore, hubspotId]);
 
   const filteredContacts = contacts.filter((contact) => {
     const searchLower = searchQuery.toLowerCase().trim();

--- a/src/app/my-contacts/contacts-table.tsx
+++ b/src/app/my-contacts/contacts-table.tsx
@@ -33,12 +33,14 @@ interface DealsTableProps {
   contacts: OwnedContacts[];
   initialTotal: number;
   after: string;
+  hubspotId?: string;
 }
 
 const OwnedContactsTable = ({
   contacts: initialContacts,
   initialTotal,
   after: initialAfter,
+  hubspotId,
 }: DealsTableProps) => {
   const router = useRouter();
   const [currentPage, setCurrentPage] = useState(1);
@@ -70,7 +72,7 @@ const OwnedContactsTable = ({
 
     setIsLoading(true);
     try {
-      const newData = await getContactsByOwnerId(currentAfter);
+      const newData = await getContactsByOwnerId(currentAfter, hubspotId);
 
       if (newData.results.length > 0) {
         setContacts((prev) => [...prev, ...newData.results]);

--- a/src/app/my-contacts/page.tsx
+++ b/src/app/my-contacts/page.tsx
@@ -8,15 +8,17 @@ export const metadata: Metadata = {
   description: "Contacts associated with sales representative.",
 };
 
+type SearchParams = {
+  hubspotId?: string;
+};
+
 const OwnedContactPage = async ({
   searchParams,
 }: {
-  searchParams: { hubspotId?: string };
+  searchParams: Promise<SearchParams>;
 }) => {
-  const ownedContacts = await getContactsByOwnerId(
-    undefined,
-    searchParams?.hubspotId
-  );
+  const params = await searchParams;
+  const ownedContacts = await getContactsByOwnerId(undefined, params.hubspotId);
 
   const contacts = ownedContacts.results;
   const total = ownedContacts.total;
@@ -33,7 +35,7 @@ const OwnedContactPage = async ({
           contacts={contacts}
           initialTotal={total}
           after={after}
-          hubspotId={searchParams?.hubspotId}
+          hubspotId={params.hubspotId}
         />
       ) : (
         <p>No contacts yet.</p>

--- a/src/app/my-contacts/page.tsx
+++ b/src/app/my-contacts/page.tsx
@@ -8,8 +8,15 @@ export const metadata: Metadata = {
   description: "Contacts associated with sales representative.",
 };
 
-const OwnedContactPage = async () => {
-  const ownedContacts = await getContactsByOwnerId();
+const OwnedContactPage = async ({
+  searchParams,
+}: {
+  searchParams: { hubspotId?: string };
+}) => {
+  const ownedContacts = await getContactsByOwnerId(
+    undefined,
+    searchParams?.hubspotId
+  );
 
   const contacts = ownedContacts.results;
   const total = ownedContacts.total;
@@ -26,6 +33,7 @@ const OwnedContactPage = async () => {
           contacts={contacts}
           initialTotal={total}
           after={after}
+          hubspotId={searchParams?.hubspotId}
         />
       ) : (
         <p>No contacts yet.</p>

--- a/src/app/my-meetings/page.tsx
+++ b/src/app/my-meetings/page.tsx
@@ -9,8 +9,12 @@ export const metadata: Metadata = {
   description: "Deals associated with contact owner.",
 };
 
-const MeetingsPage = async () => {
-  const meetings = await getAllOwnersMeetings();
+const MeetingsPage = async ({
+  searchParams,
+}: {
+  searchParams: { hubspotId?: string };
+}) => {
+  const meetings = await getAllOwnersMeetings(searchParams?.hubspotId);
 
   return (
     <div className="container mx-auto py-10">

--- a/src/app/my-meetings/page.tsx
+++ b/src/app/my-meetings/page.tsx
@@ -8,13 +8,17 @@ export const metadata: Metadata = {
   title: "My Deals",
   description: "Deals associated with contact owner.",
 };
+type SearchParams = {
+  hubspotId?: string;
+};
 
 const MeetingsPage = async ({
   searchParams,
 }: {
-  searchParams: { hubspotId?: string };
+  searchParams: Promise<SearchParams>;
 }) => {
-  const meetings = await getAllOwnersMeetings(searchParams?.hubspotId);
+  const params = await searchParams;
+  const meetings = await getAllOwnersMeetings(params.hubspotId);
 
   return (
     <div className="container mx-auto py-10">

--- a/src/app/mydeals/page.tsx
+++ b/src/app/mydeals/page.tsx
@@ -8,8 +8,12 @@ export const metadata: Metadata = {
   description: "Deals associated with contact owner.",
 };
 
-const DealsPage = async () => {
-  const deals = await getDealsByUserId();
+const DealsPage = async ({
+  searchParams,
+}: {
+  searchParams: { hubspotId?: string };
+}) => {
+  const deals = await getDealsByUserId(searchParams?.hubspotId);
 
   return (
     <div className="container mx-auto py-6">

--- a/src/app/mydeals/page.tsx
+++ b/src/app/mydeals/page.tsx
@@ -7,13 +7,17 @@ export const metadata: Metadata = {
   title: "My Deals",
   description: "Deals associated with contact owner.",
 };
+type SearchParams = {
+  hubspotId?: string;
+};
 
 const DealsPage = async ({
   searchParams,
 }: {
-  searchParams: { hubspotId?: string };
+  searchParams: Promise<SearchParams>;
 }) => {
-  const deals = await getDealsByUserId(searchParams?.hubspotId);
+  const params = await searchParams;
+  const deals = await getDealsByUserId(params.hubspotId);
 
   return (
     <div className="container mx-auto py-6">

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -5,6 +5,7 @@ import PageHeader from "@/components/PageHeader";
 type SearchParams = {
   timeRange?: "weekly" | "monthly" | "daily";
   taskId?: string;
+  hubspotId?: string;
 };
 
 export default async function Page({
@@ -24,7 +25,10 @@ export default async function Page({
         <DateRangeSelect />
       </div>
       <div className="w-full pr-4">
-        <OwnerTasksList searchParams={params} />
+        <OwnerTasksList
+          searchParams={params}
+          hubspotId={params.hubspotId}
+        />
       </div>
     </div>
   );

--- a/src/components/LeadActivities/LeadActivitiesList.tsx
+++ b/src/components/LeadActivities/LeadActivitiesList.tsx
@@ -8,15 +8,17 @@ type SearchParams = {
 
 export async function LeadsActivitiesList({
   searchParams,
+  hubspotId,
 }: {
   searchParams: SearchParams;
+  hubspotId?: string;
 }) {
   const timeRange = (searchParams.timeRange ?? "monthly") as
     | "weekly"
     | "monthly"
     | "allTime";
 
-  const result = await getLeadsBatchActivities(timeRange);
+  const result = await getLeadsBatchActivities(timeRange, undefined, hubspotId);
   const activities = result.engagements;
   const nextAfter = result.nextAfter;
 

--- a/src/components/LeadsQualifier/LeadsQualifiedList.tsx
+++ b/src/components/LeadsQualifier/LeadsQualifiedList.tsx
@@ -10,14 +10,16 @@ type SearchParams = { timeRange?: "weekly" | "monthly" | "allTime" };
 
 export async function LeadsQualifiedList({
   searchParams,
+  hubspotId,
 }: {
   searchParams: SearchParams;
+  hubspotId?: string;
 }) {
   const timeRange = (searchParams.timeRange ?? "monthly") as
     | "weekly"
     | "monthly"
     | "allTime";
-  const leads = await getQualifiedLeads(timeRange);
+  const leads = await getQualifiedLeads(timeRange, hubspotId);
 
   const leadsIds = leads.map((lead: LeadProps) => lead.id);
 

--- a/src/components/OwnerTasks/OwnerTasksList.tsx
+++ b/src/components/OwnerTasks/OwnerTasksList.tsx
@@ -12,8 +12,10 @@ type SearchParams = {
 
 export async function OwnerTasksList({
   searchParams,
+  hubspotId,
 }: {
   searchParams: SearchParams;
+  hubspotId?: string;
 }) {
   let timeRange: "daily" | "weekly" | "monthly" = "monthly";
 
@@ -33,7 +35,8 @@ export async function OwnerTasksList({
     timeRange,
     undefined,
     searchParams.from,
-    searchParams.to
+    searchParams.to,
+    hubspotId
   );
 
   const tasks = result.tasks || [];
@@ -46,6 +49,7 @@ export async function OwnerTasksList({
         timeRange={timeRange}
         initialNextAfter={nextAfter}
         initialTaskId={searchParams.taskId}
+        hubspotId={hubspotId}
       />
     </Suspense>
   );

--- a/src/components/OwnerTasks/TasksTable.tsx
+++ b/src/components/OwnerTasks/TasksTable.tsx
@@ -49,6 +49,7 @@ interface TasksTableProps {
   timeRange: "weekly" | "monthly" | "daily";
   initialNextAfter?: string;
   initialTaskId?: string;
+  hubspotId?: string;
 }
 
 export function TasksTable({
@@ -56,6 +57,7 @@ export function TasksTable({
   timeRange,
   initialNextAfter,
   initialTaskId,
+  hubspotId,
 }: TasksTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedLeadId, setSelectedLeadId] = useState<string | null>(null);
@@ -112,7 +114,7 @@ export function TasksTable({
 
     setIsLoading(true);
     try {
-      const result = await getUserBatchTasks(timeRange, nextAfter);
+      const result = await getUserBatchTasks(timeRange, nextAfter, undefined, undefined, hubspotId);
 
       if (result.tasks && result.tasks.length > 0) {
         setTasks((prev) => [...prev, ...result.tasks]);

--- a/src/components/OwnerTasks/TasksTable.tsx
+++ b/src/components/OwnerTasks/TasksTable.tsx
@@ -114,7 +114,13 @@ export function TasksTable({
 
     setIsLoading(true);
     try {
-      const result = await getUserBatchTasks(timeRange, nextAfter, undefined, undefined, hubspotId);
+      const result = await getUserBatchTasks(
+        timeRange,
+        nextAfter,
+        undefined,
+        undefined,
+        hubspotId
+      );
 
       if (result.tasks && result.tasks.length > 0) {
         setTasks((prev) => [...prev, ...result.tasks]);
@@ -129,7 +135,7 @@ export function TasksTable({
     } finally {
       setIsLoading(false);
     }
-  }, [timeRange, nextAfter, isLoading, hasMore]);
+  }, [timeRange, nextAfter, isLoading, hasMore, hubspotId]);
 
   const filterGroups = useMemo<FilterGroup[]>(() => {
     const statuses = new Set<string>();

--- a/src/hooks/useIncompleteTasks.ts
+++ b/src/hooks/useIncompleteTasks.ts
@@ -4,10 +4,10 @@ import { Task } from "@/types/Tasks";
 
 const ONE_HOUR = 1000 * 60 * 60;
 
-export function useIncompleteTasks() {
+export function useIncompleteTasks(hubspotOwnerId?: string) {
   return useQuery<Task[]>({
-    queryKey: ["incompleteTasks"],
-    queryFn: getIncompleteTasks,
+    queryKey: ["incompleteTasks", hubspotOwnerId],
+    queryFn: () => getIncompleteTasks(hubspotOwnerId),
     staleTime: ONE_HOUR,
     gcTime: ONE_HOUR,
     refetchInterval: ONE_HOUR,


### PR DESCRIPTION
## Summary
- add optional `hubspotOwnerId` argument to many HubSpot actions
- allow loading contacts, deals, meetings and tasks for a specified id
- wire through `hubspotId` query param in dashboard pages and components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687418880dd483318721a98672813347