### PR TITLE
feat: add Orders section to resources with navigation and loading state

### DIFF
--- a/src/app/resources/SidebarResources.tsx
+++ b/src/app/resources/SidebarResources.tsx
@@ -8,6 +8,7 @@ import {
   MapPin,
   CreditCard,
   Wrench,
+  Table2,
 } from "lucide-react";
 import {
   SidebarMenuItem,
@@ -60,6 +61,11 @@ const toolsItems: ResourceItem[] = [
     title: "Payment Info",
     icon: CreditCard,
     path: "/resources/payment",
+  },
+  {
+    title: "Orders",
+    icon: Table2,
+    path: "/resources/orders",
   },
 ];
 

--- a/src/app/resources/orders/OrdersSheet.tsx
+++ b/src/app/resources/orders/OrdersSheet.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function OrdersSheet() {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // safety net: hide skeleton after 6s even if onLoad never fires
+    const t = setTimeout(() => setLoading(false), 6000);
+    return () => clearTimeout(t);
+  }, []);
+
+  const handleLoad = () => {
+    setLoading(false);
+  };
+  const handleError = () => {
+    setLoading(false);
+    console.error("Failed to load orders sheet");
+  };
+
+  return (
+    <div className="h-[calc(100vh-12rem)] w-full rounded-2xl border bg-white overflow-hidden relative">
+      {loading && (
+        <div className="absolute inset-0 p-4 space-y-2 bg-white">
+          <Skeleton className="h-8 w-48 mb-4" />
+          {Array.from({ length: 10 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full" />
+          ))}
+        </div>
+      )}
+
+      <iframe
+        src={process.env.NEXT_PUBLIC_ORDERS_SHEET_URL}
+        className="h-full w-full"
+        loading="eager"
+        sandbox="allow-same-origin allow-scripts"
+        referrerPolicy="no-referrer"
+        allowFullScreen
+        title="Orders Sheet"
+        onLoad={handleLoad}
+        onError={handleError}
+      />
+    </div>
+  );
+}

--- a/src/app/resources/orders/page.tsx
+++ b/src/app/resources/orders/page.tsx
@@ -1,0 +1,26 @@
+import PageHeader from "@/components/PageHeader";
+import OrdersSheet from "./OrdersSheet";
+
+export const metadata = {
+  title: "Orders | MBTEK Sales Dashboard",
+  description: "View and manage orders in the Google Sheets interface.",
+};
+
+const OrdersPage = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <PageHeader
+        title="Orders"
+        subtitle="View and manage orders in real-time"
+      />
+      <div className="mt-6">
+        <div className="mb-4 text-sm text-muted-foreground">
+          Resources / Tools / Orders
+        </div>
+        <OrdersSheet />
+      </div>
+    </div>
+  );
+};
+
+export default OrdersPage;

--- a/src/app/resources/resources-grid.tsx
+++ b/src/app/resources/resources-grid.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   ClipboardList,
   Check,
+  Table2,
 } from "lucide-react";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { useRouter } from "next/navigation";
@@ -54,6 +55,15 @@ export default function ResourcesGrid() {
       ],
       onClick: () => {
         router.push("/resources/payment");
+      },
+    },
+    {
+      icon: <Table2 className="h-6 w-6" />,
+      title: "Orders",
+      subtitle: "Order management",
+      items: ["View order status", "Track shipments", "Order history"],
+      onClick: () => {
+        router.push("/resources/orders");
       },
     },
     /* {


### PR DESCRIPTION
This pull request introduces a new "Orders" resource to the sidebar and resources grid, allowing users to view and manage orders through an embedded Google Sheets interface. The main changes include updating navigation components to add the Orders entry, and implementing the new Orders page and sheet display with loading skeletons for improved UX.

### Orders Resource Addition

* Added a new "Orders" entry to the sidebar menu (`SidebarResources.tsx`) and resources grid (`resources-grid.tsx`), with the `Table2` icon and navigation to `/resources/orders`. [[1]](diffhunk://#diff-78ed60e96d02c551a707e420064eb558d2400b7f1e68e63e9727812e64f1ca2cR11) [[2]](diffhunk://#diff-78ed60e96d02c551a707e420064eb558d2400b7f1e68e63e9727812e64f1ca2cR65-R69) [[3]](diffhunk://#diff-b5c46de6f670d9495cf6cca8d49c2d086b28486cd6fc2bb7572c197f717c526bR11) [[4]](diffhunk://#diff-b5c46de6f670d9495cf6cca8d49c2d086b28486cd6fc2bb7572c197f717c526bR60-R68)

### Orders Page Implementation

* Created a new `OrdersPage` (`orders/page.tsx`) with a header and descriptive text, rendering the `OrdersSheet` component for order management.

### OrdersSheet Component

* Implemented `OrdersSheet` (`orders/OrdersSheet.tsx`), which displays an embedded Google Sheet in an iframe, includes a loading skeleton for better user experience, and handles load/error events gracefully.